### PR TITLE
Fix silent Bcc drop by passing explicit Destination to SES v2

### DIFF
--- a/app/Jobs/SendQueuedEmail.php
+++ b/app/Jobs/SendQueuedEmail.php
@@ -30,7 +30,7 @@ class SendQueuedEmail implements ShouldQueue
 
     public function handle(SesV2Client $sesClient): void
     {
-        $email = Email::query()->with('source')->findOrFail($this->emailId);
+        $email = Email::query()->with(['source', 'recipients'])->findOrFail($this->emailId);
 
         // 'sending' is allowed through so a retry can recover an email whose
         // previous attempt died mid-flight (worker crash, timeout).
@@ -50,7 +50,7 @@ class SendQueuedEmail implements ShouldQueue
                 throw new \RuntimeException("Stored MIME content is missing for {$email->public_id}.");
             }
 
-            $result = $sesClient->sendRawEmail($email->source, $mime);
+            $result = $sesClient->sendRawEmail($email->source, $mime, $this->destination($email));
         } catch (Throwable $exception) {
             // Stay in 'sending' so the queue's remaining attempts get past the
             // status guard above; failed() marks it failed after the last one.
@@ -74,6 +74,20 @@ class SendQueuedEmail implements ShouldQueue
         ]);
 
         EmailActivityUpdated::dispatch($email->fresh());
+    }
+
+    /**
+     * @return array{ToAddresses?: array<int, string>, CcAddresses?: array<int, string>, BccAddresses?: array<int, string>}
+     */
+    private function destination(Email $email): array
+    {
+        $grouped = $email->recipients->groupBy('type');
+
+        return array_filter([
+            'ToAddresses' => $grouped->get('to', collect())->pluck('email')->all(),
+            'CcAddresses' => $grouped->get('cc', collect())->pluck('email')->all(),
+            'BccAddresses' => $grouped->get('bcc', collect())->pluck('email')->all(),
+        ]);
     }
 
     public function failed(Throwable $exception): void

--- a/app/Services/SesV2Client.php
+++ b/app/Services/SesV2Client.php
@@ -87,19 +87,30 @@ class SesV2Client
     }
 
     /**
+     * The explicit Destination is required for Bcc delivery: Symfony Mime
+     * strips the Bcc header from the raw message, so SES cannot derive
+     * Bcc recipients from the MIME headers alone.
+     *
+     * @param  array{ToAddresses?: array<int, string>, CcAddresses?: array<int, string>, BccAddresses?: array<int, string>}  $destination
      * @return array{message_id: string|null, response: array<string, mixed>}
      */
-    public function sendRawEmail(Source $source, string $mime): array
+    public function sendRawEmail(Source $source, string $mime, array $destination = []): array
     {
         $target = "https://email.{$source->ses_region}.amazonaws.com/v2/email/outbound-emails";
-        $payload = json_encode([
+        $body = [
             'Content' => [
                 'Raw' => [
                     'Data' => base64_encode($mime),
                 ],
             ],
             'ConfigurationSetName' => $source->ses_configuration_set,
-        ], JSON_THROW_ON_ERROR);
+        ];
+
+        if ($destination !== []) {
+            $body['Destination'] = $destination;
+        }
+
+        $payload = json_encode($body, JSON_THROW_ON_ERROR);
 
         $headers = $this->signedHeaders($source, 'POST', $target, $payload);
         $response = Http::withHeaders($headers)

--- a/tests/Feature/ApiEmailTest.php
+++ b/tests/Feature/ApiEmailTest.php
@@ -9,6 +9,8 @@ use App\Models\Suppression;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\SesV2Client;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 
 function larasendProjectFixture(): array
@@ -166,7 +168,7 @@ it('sends queued email jobs through ses and records the response', function () {
 
     (new SendQueuedEmail($email->id))->handle(new class extends SesV2Client
     {
-        public function sendRawEmail(Source $source, string $mime): array
+        public function sendRawEmail(Source $source, string $mime, array $destination = []): array
         {
             expect($mime)->toContain('Welcome to Larasend');
 
@@ -181,6 +183,48 @@ it('sends queued email jobs through ses and records the response', function () {
         ->status->toBe('sent')
         ->ses_message_id->toBe('ses-message-1')
         ->and($email->events()->where('event_type', 'send')->exists())->toBeTrue();
+});
+
+it('sends bcc recipients through an explicit ses destination', function () {
+    [$workspace, $project, $source, $token] = larasendProjectFixture();
+
+    Queue::fake();
+    Http::fake([
+        'https://email.*.amazonaws.com/v2/email/outbound-emails' => Http::response(['MessageId' => 'ses-message-2']),
+    ]);
+
+    $this->withToken($token)->postJson('/api/emails', [
+        'from' => 'Larasend <receipts@example.com>',
+        'to' => ['Maya <maya@example.com>'],
+        'cc' => ['Ana <ana@example.com>'],
+        'bcc' => ['Bea <bea@example.com>'],
+        'subject' => 'Monthly invoice',
+        'html' => '<h1>Hello Maya</h1>',
+        'text' => 'Hello Maya',
+    ])->assertAccepted();
+
+    $email = Email::query()->firstOrFail();
+
+    expect($email->recipients()->where('type', 'bcc')->pluck('email')->all())->toBe(['bea@example.com']);
+
+    (new SendQueuedEmail($email->id))->handle(app(SesV2Client::class));
+
+    Http::assertSent(function (Request $request): bool {
+        if (! str_contains($request->url(), '/v2/email/outbound-emails')) {
+            return false;
+        }
+
+        $destination = $request->data()['Destination'] ?? [];
+
+        return ($destination['ToAddresses'] ?? []) === ['maya@example.com']
+            && ($destination['CcAddresses'] ?? []) === ['ana@example.com']
+            && ($destination['BccAddresses'] ?? []) === ['bea@example.com'];
+    });
+
+    expect($email->fresh()->status)->toBe('sent')
+        ->and($email->fresh()->ses_message_id)->toBe('ses-message-2')
+        ->and($workspace)->toBeInstanceOf(Workspace::class)
+        ->and($project)->toBeInstanceOf(Project::class);
 });
 
 it('blocks sends to suppressed recipients', function () {


### PR DESCRIPTION
## Summary

Bcc recipients were accepted by the API and stored in the database, but silently never delivered. Symfony Mime strips the `Bcc` header when serializing a message (`Message::getPreparedHeaders()` removes it, per RFC — Bcc should not appear in the sent message), and `SesV2Client::sendRawEmail()` posted only `Content.Raw` with no `Destination` field, so SES v2 derived recipients solely from the MIME headers — which no longer contained the Bcc addresses.

## Changes

- **`app/Services/SesV2Client.php`** — `sendRawEmail()` accepts an optional `Destination` (`ToAddresses`/`CcAddresses`/`BccAddresses`) and includes it in the SES v2 SendEmail payload when non-empty. When `Destination` is present, SES delivers to exactly those addresses while the MIME headers stay as-is — correct Bcc semantics (delivered, not visible in headers).
- **`app/Jobs/SendQueuedEmail.php`** — eager-loads the `recipients` relation and builds the `Destination` from the stored recipient rows grouped by `to`/`cc`/`bcc` type.

## Testing

- New feature test `sends bcc recipients through an explicit ses destination` drives the full pipeline: API request with to/cc/bcc → `SendQueuedEmail` running against the real `SesV2Client` with `Http::fake()` — and asserts the actual JSON payload posted to `/v2/email/outbound-emails` contains all three address lists in `Destination`.
- Updated the existing anonymous `SesV2Client` test double to match the new method signature.
- `php artisan test --compact --filter=ApiEmail`: 12 passed (60 assertions). Pint clean.

## Note (pre-existing, not addressed here)

SES caps `Destination` at 50 total recipients per call while API validation allows up to 1000 per field. This limit applied equally before this change; batching large recipient lists would be a separate improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)