### PR TITLE
Add inbound email receiving for Cloudflare sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Larasend is built with Laravel, Inertia, Vue, PostgreSQL, Redis, and Docker.
 - Project-scoped API keys with scopes, expiration, rotation, and last-used metadata.
 - Activity dashboard with status filters, search, grouped timeline, inspector preview, headers, metrics, and resend.
 - Provider choice per source: Amazon SES or Cloudflare Email Service.
+- Inbound email on Cloudflare sources: one click deploys a Worker and routing rule, received mail lands in the dashboard and fires `inbound.received` webhooks.
 - SES identity setup with DKIM record guidance; Cloudflare domain verification via DNS checks.
 - SES event ingestion for delivery, bounce, complaint, open, click, and suppression events.
 - Hourly Cloudflare suppression-list sync (Cloudflare has no event webhooks or open/click tracking).
@@ -122,6 +123,8 @@ Requirements:
 - The sending domain must be an active zone on your Cloudflare account (Cloudflare DNS).
 - The account must be on the Workers Paid plan (includes 3,000 emails/month, then $0.35 per 1,000).
 - Email Service is for transactional email only, which matches what Larasend is for.
+
+Inbound email is supported on Cloudflare sources: enabling "Receive email" on a domain deploys a small Cloudflare Worker and points the zone's catch-all routing rule at it, so mail sent to any address on the zone apex lands in the Inbound section and fires `inbound.received` webhooks to your subscribed endpoints. The token additionally needs "Workers Scripts: Edit" and "Email Routing Rules: Edit" for this (added manually; the pre-filled link covers sending only).
 
 Recommended setup:
 

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -137,7 +137,13 @@ class ActivityController extends Controller
                 'can_send' => $canSend,
                 'capabilities' => $this->sourceCapabilities($source),
             ] : null,
-            'domains' => $project->domains()->latest()->get(['id', 'domain', 'status', 'dns_records', 'verified_at']),
+            'domains' => $project->domains()->latest()->get(['id', 'domain', 'status', 'dns_records', 'verified_at', 'inbound_enabled_at']),
+            'inboundEmails' => $section === 'inbound'
+                ? $project->inboundEmails()
+                    ->latest('received_at')
+                    ->limit(50)
+                    ->get(['public_id', 'from_email', 'from_name', 'to_email', 'subject', 'text', 'html', 'attachments', 'received_at'])
+                : [],
             'templates' => $project->templates()->latest()->get(['slug', 'name', 'subject', 'html', 'text', 'variables', 'updated_at']),
             'webhooks' => $this->webhookEndpoints($project),
             'webhookStats' => $this->webhookStats($project),
@@ -152,6 +158,7 @@ class ActivityController extends Controller
             'setup' => $this->setup($project, $source, $context),
             'sidebarCounts' => [
                 'activity' => $project->emails()->count(),
+                'inbound' => $project->inboundEmails()->count(),
                 'sent' => $project->emails()->whereIn('status', ['sent', 'delivered', 'opened', 'clicked'])->count(),
                 'bounces' => $project->emails()->where('status', 'bounced')->count(),
                 'complaints' => $project->emails()->where('status', 'complained')->count(),

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -155,6 +155,7 @@ class ActivityController extends Controller
                 : null,
             'apiKeys' => $project->apiKeys()->latest()->get(['id', 'name', 'prefix', 'scopes', 'last_used_at', 'last_used_ip', 'last_used_user_agent', 'expires_at', 'created_at']),
             'newApiKey' => session('newApiKey'),
+            'inboundError' => session('inboundError'),
             'setup' => $this->setup($project, $source, $context),
             'sidebarCounts' => [
                 'activity' => $project->emails()->count(),

--- a/app/Http/Controllers/DashboardActionController.php
+++ b/app/Http/Controllers/DashboardActionController.php
@@ -476,7 +476,10 @@ class DashboardActionController extends Controller
         } catch (RuntimeException $exception) {
             Inertia::flash('toast', ['type' => 'error', 'message' => $exception->getMessage()]);
 
-            return $this->toProjectSection($project, 'identities');
+            // Also surfaced inline on the Receive email card: a transient
+            // toast is not enough feedback for an actionable failure.
+            return $this->toProjectSection($project, 'identities')
+                ->with('inboundError', $exception->getMessage());
         }
 
         $zoneApex = str($domain->domain)->explode('.')->slice(-2)->implode('.');

--- a/app/Http/Controllers/DashboardActionController.php
+++ b/app/Http/Controllers/DashboardActionController.php
@@ -19,6 +19,7 @@ use App\Models\User;
 use App\Models\WebhookEndpoint;
 use App\Services\DnsRecordVerifier;
 use App\Services\EmailSendService;
+use App\Services\Providers\CloudflareInboundProvisioner;
 use App\Services\Providers\DomainOnboardingException;
 use App\Services\Providers\EmailProviderFactory;
 use App\Support\ProjectContext;
@@ -441,6 +442,49 @@ class DashboardActionController extends Controller
         $dnsVerifier->recheck($domain);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => 'DNS records re-checked.']);
+
+        return $this->toProjectSection($project, 'identities');
+    }
+
+    public function enableDomainInbound(Domain $domain, CloudflareInboundProvisioner $provisioner): RedirectResponse
+    {
+        return $this->provisionInbound($domain, $provisioner);
+    }
+
+    public function enableProjectDomainInbound(string $projectSlug, Domain $domain, CloudflareInboundProvisioner $provisioner): RedirectResponse
+    {
+        return $this->provisionInbound($domain, $provisioner);
+    }
+
+    private function provisionInbound(Domain $domain, CloudflareInboundProvisioner $provisioner): RedirectResponse
+    {
+        $project = $this->projectFor(Auth::user());
+        $this->authorizeWorkspaceCapability($project, 'manage_domains');
+
+        abort_unless($domain->project_id === $project->id, 404);
+
+        $source = $this->sourceFor($project);
+
+        if ($source->provider !== SourceProvider::Cloudflare) {
+            Inertia::flash('toast', ['type' => 'error', 'message' => 'Inbound email currently requires a Cloudflare source.']);
+
+            return $this->toProjectSection($project, 'identities');
+        }
+
+        try {
+            $provisioner->enable($source, $domain);
+        } catch (RuntimeException $exception) {
+            Inertia::flash('toast', ['type' => 'error', 'message' => $exception->getMessage()]);
+
+            return $this->toProjectSection($project, 'identities');
+        }
+
+        $zoneApex = str($domain->domain)->explode('.')->slice(-2)->implode('.');
+
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => "Inbound email enabled. Mail sent to any address @{$zoneApex} now appears in the Inbound section.",
+        ]);
 
         return $this->toProjectSection($project, 'identities');
     }

--- a/app/Http/Controllers/Webhooks/CloudflareInboundController.php
+++ b/app/Http/Controllers/Webhooks/CloudflareInboundController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Webhooks;
+
+use App\Enums\SourceProvider;
+use App\Http\Controllers\Controller;
+use App\Models\Source;
+use App\Models\WebhookLog;
+use App\Services\InboundEmailIngestor;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+class CloudflareInboundController extends Controller
+{
+    /**
+     * Raw messages above this size are rejected. Mirrors what a small
+     * self-hosted install can comfortably buffer in one request.
+     */
+    private const MAX_MESSAGE_BYTES = 26_214_400; // 25 MiB
+
+    public function __invoke(Request $request, string $token, InboundEmailIngestor $ingestor): JsonResponse
+    {
+        $source = Source::query()
+            ->where('webhook_token', $token)
+            ->where('provider', SourceProvider::Cloudflare)
+            ->firstOrFail();
+
+        $validated = $request->validate([
+            'from' => ['required', 'string', 'max:320'],
+            'to' => ['required', 'string', 'max:320'],
+            'raw' => ['required', 'string'],
+        ]);
+
+        $log = WebhookLog::create([
+            'source_id' => $source->id,
+            'provider' => 'cloudflare',
+            'message_type' => 'inbound_email',
+            'status' => 'received',
+            'payload' => [
+                'from' => $validated['from'],
+                'to' => $validated['to'],
+                'raw_bytes' => (int) (strlen($validated['raw']) * 3 / 4),
+            ],
+        ]);
+
+        $mime = base64_decode($validated['raw'], strict: true);
+
+        if ($mime === false || $mime === '') {
+            $log->forceFill(['status' => 'rejected', 'error' => 'Raw message is not valid base64.'])->save();
+
+            return response()->json(['message' => 'Raw message is not valid base64.'], 422);
+        }
+
+        if (strlen($mime) > self::MAX_MESSAGE_BYTES) {
+            $log->forceFill(['status' => 'rejected', 'error' => 'Message exceeds the maximum accepted size.'])->save();
+
+            return response()->json(['message' => 'Message too large.'], 413);
+        }
+
+        try {
+            $inbound = $ingestor->ingest($source, $validated['from'], $validated['to'], $mime);
+        } catch (Throwable $exception) {
+            report($exception);
+            $log->forceFill(['status' => 'failed', 'error' => $exception->getMessage()])->save();
+
+            // A 5xx makes the Worker throw, which defers the message so the
+            // sending server retries instead of the email being lost.
+            return response()->json(['message' => 'Ingestion failed.'], 500);
+        }
+
+        $log->forceFill(['status' => 'processed'])->save();
+
+        return response()->json(['id' => $inbound->public_id], 202);
+    }
+}

--- a/app/Http/Requests/StoreDomainRequest.php
+++ b/app/Http/Requests/StoreDomainRequest.php
@@ -3,12 +3,26 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 
 class StoreDomainRequest extends FormRequest
 {
     public function authorize(): bool
     {
         return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $identity = trim($this->string('domain')->toString());
+
+        if (str_contains($identity, '@')) {
+            $identity = trim(Str::afterLast($identity, '@'), " \t\n\r\0\x0B<>.,;");
+        }
+
+        $this->merge([
+            'domain' => Str::lower($identity),
+        ]);
     }
 
     /**

--- a/app/Http/Requests/StoreWebhookEndpointRequest.php
+++ b/app/Http/Requests/StoreWebhookEndpointRequest.php
@@ -26,7 +26,7 @@ class StoreWebhookEndpointRequest extends FormRequest
         return [
             'url' => ['required', 'url:http,https', 'max:2048'],
             'events' => ['required', 'array', 'min:1'],
-            'events.*' => ['string', Rule::in(['delivery', 'bounce', 'complaint', 'open', 'click', 'suppress'])],
+            'events.*' => ['string', Rule::in(['delivery', 'bounce', 'complaint', 'open', 'click', 'suppress', 'inbound.received'])],
             'status' => ['required', Rule::in(['active', 'paused'])],
         ];
     }

--- a/app/Jobs/DeliverInboundWebhook.php
+++ b/app/Jobs/DeliverInboundWebhook.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\InboundEmail;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookEndpoint;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Fans an inbound email out to every active endpoint subscribed to the
+ * "inbound.received" event, using the same signature scheme and delivery
+ * records as outbound event webhooks.
+ */
+class DeliverInboundWebhook implements ShouldQueue
+{
+    use Queueable;
+
+    public const EVENT_TYPE = 'inbound.received';
+
+    public int $tries = 3;
+
+    public int $timeout = 30;
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [5, 30, 120];
+    }
+
+    public function __construct(public int $inboundEmailId) {}
+
+    public function handle(): void
+    {
+        $inbound = InboundEmail::query()->with('project')->find($this->inboundEmailId);
+
+        if (! $inbound || ! $inbound->project) {
+            return;
+        }
+
+        $inbound->project
+            ->webhookEndpoints()
+            ->where('status', 'active')
+            ->whereJsonContains('events', self::EVENT_TYPE)
+            ->each(function (WebhookEndpoint $endpoint) use ($inbound): void {
+                $this->deliver($endpoint, $inbound);
+            });
+    }
+
+    private function deliver(WebhookEndpoint $endpoint, InboundEmail $inbound): void
+    {
+        $payload = $this->payload($inbound);
+        $body = json_encode($payload, JSON_THROW_ON_ERROR);
+        $startedAt = hrtime(true);
+
+        try {
+            $response = Http::withHeaders($this->headers($endpoint, $inbound, $body))
+                ->acceptJson()
+                ->connectTimeout(5)
+                ->timeout(10)
+                ->withBody($body, 'application/json')
+                ->post($endpoint->url);
+
+            $delivery = $this->recordDelivery(
+                endpoint: $endpoint,
+                payload: $payload,
+                status: $response->successful() ? 'ok' : 'fail',
+                httpStatus: $response->status(),
+                latencyMs: $this->latencyMs($startedAt),
+                responseBody: Str::limit($response->body(), 2000, ''),
+            );
+
+            if ($response->successful()) {
+                $endpoint->forceFill(['last_delivered_at' => $delivery->delivered_at])->save();
+            }
+        } catch (ConnectionException $exception) {
+            $this->recordDelivery(
+                endpoint: $endpoint,
+                payload: $payload,
+                status: 'fail',
+                httpStatus: null,
+                latencyMs: $this->latencyMs($startedAt),
+                responseBody: Str::limit($exception->getMessage(), 2000, ''),
+            );
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(InboundEmail $inbound): array
+    {
+        return [
+            'id' => 'evt_inbound_'.$inbound->id,
+            'type' => self::EVENT_TYPE,
+            'created_at' => $inbound->received_at->toIso8601String(),
+            'data' => [
+                'inbound_email' => [
+                    'id' => $inbound->public_id,
+                    'from' => trim(($inbound->from_name ? $inbound->from_name.' ' : '').'<'.$inbound->from_email.'>'),
+                    'to' => $inbound->to_email,
+                    'subject' => $inbound->subject,
+                    'text' => $inbound->text,
+                    'html' => $inbound->html,
+                    'headers' => $inbound->headers,
+                    'attachments' => $inbound->attachments,
+                    'message_id' => $inbound->message_id,
+                    'in_reply_to' => $inbound->in_reply_to,
+                    'received_at' => $inbound->received_at->toIso8601String(),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headers(WebhookEndpoint $endpoint, InboundEmail $inbound, string $body): array
+    {
+        $timestamp = (string) now()->getTimestamp();
+        $signature = hash_hmac('sha256', $timestamp.'.'.$body, $endpoint->signing_secret);
+
+        return [
+            'Larasend-Event-Id' => 'evt_inbound_'.$inbound->id,
+            'Larasend-Event-Type' => self::EVENT_TYPE,
+            'Larasend-Signature' => "t={$timestamp},v1={$signature}",
+            'User-Agent' => 'Larasend-Webhooks/1.0',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function recordDelivery(
+        WebhookEndpoint $endpoint,
+        array $payload,
+        string $status,
+        ?int $httpStatus,
+        int $latencyMs,
+        string $responseBody,
+    ): WebhookDelivery {
+        return WebhookDelivery::query()->create([
+            'webhook_endpoint_id' => $endpoint->id,
+            'public_id' => 'whd_'.Str::lower(Str::random(16)),
+            'event_type' => self::EVENT_TYPE,
+            'http_status' => $httpStatus,
+            'latency_ms' => $latencyMs,
+            'status' => $status,
+            'payload' => $payload,
+            'response_body' => $responseBody,
+            'delivered_at' => now(),
+        ]);
+    }
+
+    private function latencyMs(int $startedAt): int
+    {
+        return (int) round((hrtime(true) - $startedAt) / 1_000_000);
+    }
+}

--- a/app/Models/InboundEmail.php
+++ b/app/Models/InboundEmail.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InboundEmail extends Model
+{
+    protected $fillable = [
+        'public_id',
+        'workspace_id',
+        'project_id',
+        'source_id',
+        'from_email',
+        'from_name',
+        'to_email',
+        'subject',
+        'text',
+        'html',
+        'headers',
+        'attachments',
+        'message_id',
+        'in_reply_to',
+        'mime_disk',
+        'mime_path',
+        'mime_size',
+        'received_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'headers' => 'array',
+            'attachments' => 'array',
+            'received_at' => 'datetime',
+        ];
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(Source::class);
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -65,4 +65,9 @@ class Project extends Model
     {
         return $this->hasMany(Suppression::class);
     }
+
+    public function inboundEmails(): HasMany
+    {
+        return $this->hasMany(InboundEmail::class);
+    }
 }

--- a/app/Services/CloudflareApiClient.php
+++ b/app/Services/CloudflareApiClient.php
@@ -248,6 +248,70 @@ class CloudflareApiClient
         }
     }
 
+    /**
+     * Upload (or overwrite) a single-file ES module Worker with plain-text
+     * environment bindings. Used to deploy the inbound email passthrough.
+     *
+     * @param  array<string, string>  $vars
+     */
+    public function uploadWorker(Source $source, string $scriptName, string $code, array $vars): void
+    {
+        $metadata = [
+            'main_module' => 'worker.js',
+            'compatibility_date' => '2025-01-01',
+            'bindings' => collect($vars)
+                ->map(fn (string $text, string $name): array => [
+                    'type' => 'plain_text',
+                    'name' => $name,
+                    'text' => $text,
+                ])
+                ->values()
+                ->all(),
+        ];
+
+        $response = Http::withToken((string) $source->cloudflare_api_token)
+            ->acceptJson()
+            ->timeout(30)
+            ->attach('metadata', json_encode($metadata, JSON_THROW_ON_ERROR), 'metadata.json', ['Content-Type' => 'application/json'])
+            ->attach('worker.js', $code, 'worker.js', ['Content-Type' => 'application/javascript+module'])
+            ->put("https://api.cloudflare.com/client/v4/accounts/{$source->cloudflare_account_id}/workers/scripts/{$scriptName}");
+
+        $this->ensureSuccessful($response);
+    }
+
+    public function enableEmailRouting(Source $source, string $zoneId): void
+    {
+        $response = $this->rootRequest($source)->post("/zones/{$zoneId}/email/routing/enable");
+
+        if ($response->successful()) {
+            return;
+        }
+
+        // Already enabled is success for our purposes.
+        $alreadyEnabled = collect($response->json('errors') ?? [])
+            ->contains(fn (array $error): bool => str_contains(strtolower((string) ($error['message'] ?? '')), 'already enabled'));
+
+        if (! $alreadyEnabled) {
+            $this->ensureSuccessful($response);
+        }
+    }
+
+    /**
+     * Point the zone's catch-all routing rule at a Worker so every address
+     * on the domain is delivered to it.
+     */
+    public function routeCatchAllToWorker(Source $source, string $zoneId, string $workerName): void
+    {
+        $response = $this->rootRequest($source)->put("/zones/{$zoneId}/email/routing/rules/catch_all", [
+            'name' => 'Larasend inbound',
+            'enabled' => true,
+            'matchers' => [['type' => 'all']],
+            'actions' => [['type' => 'worker', 'value' => [$workerName]]],
+        ]);
+
+        $this->ensureSuccessful($response);
+    }
+
     private function request(Source $source): PendingRequest
     {
         return Http::withToken((string) $source->cloudflare_api_token)

--- a/app/Services/InboundEmailIngestor.php
+++ b/app/Services/InboundEmailIngestor.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\DeliverInboundWebhook;
+use App\Models\InboundEmail;
+use App\Models\Source;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use ZBateson\MailMimeParser\Header\HeaderConsts;
+use ZBateson\MailMimeParser\IMessage;
+use ZBateson\MailMimeParser\MailMimeParser;
+
+/**
+ * Provider-agnostic inbound pipeline: every receiving adapter (Cloudflare
+ * Worker today, SES/S3 or SMTP later) delivers an envelope plus raw MIME
+ * here, and everything downstream — storage, parsing, webhook fan-out —
+ * is shared.
+ */
+class InboundEmailIngestor
+{
+    public function __construct(private MailMimeParser $parser) {}
+
+    public function ingest(Source $source, string $envelopeFrom, string $envelopeTo, string $mime): InboundEmail
+    {
+        $project = $source->project;
+        $publicId = 'inbound_'.Str::random(24);
+
+        $mimePath = "inbound/{$project->id}/{$publicId}.eml";
+        Storage::disk('local')->put($mimePath, $mime);
+
+        $message = $this->parser->parse($mime, autoClose: true);
+
+        $inbound = InboundEmail::create([
+            'public_id' => $publicId,
+            'workspace_id' => $project->workspace_id,
+            'project_id' => $project->id,
+            'source_id' => $source->id,
+            'from_email' => $this->headerAddress($message) ?? $envelopeFrom,
+            'from_name' => $message->getHeader(HeaderConsts::FROM)?->getPersonName() ?: null,
+            'to_email' => $envelopeTo,
+            'subject' => $message->getSubject(),
+            'text' => $message->getTextContent(),
+            'html' => $message->getHtmlContent(),
+            'headers' => $this->interestingHeaders($message),
+            'attachments' => $this->attachmentMetadata($message),
+            'message_id' => trim((string) $message->getHeaderValue(HeaderConsts::MESSAGE_ID), '<>') ?: null,
+            'in_reply_to' => trim((string) $message->getHeaderValue(HeaderConsts::IN_REPLY_TO), '<>') ?: null,
+            'mime_disk' => 'local',
+            'mime_path' => $mimePath,
+            'mime_size' => strlen($mime),
+            'received_at' => now(),
+        ]);
+
+        DeliverInboundWebhook::dispatch($inbound->id)->onQueue('webhooks');
+
+        return $inbound;
+    }
+
+    private function headerAddress(IMessage $message): ?string
+    {
+        $from = $message->getHeader(HeaderConsts::FROM);
+
+        return $from?->getEmail() ?: null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function interestingHeaders(IMessage $message): array
+    {
+        $headers = [];
+
+        foreach (['From', 'To', 'Cc', 'Reply-To', 'Date', 'Message-ID', 'In-Reply-To', 'References', 'Subject'] as $name) {
+            $value = $message->getHeaderValue($name);
+
+            if (filled($value)) {
+                $headers[$name] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Metadata only — attachment content stays inside the stored raw MIME.
+     *
+     * @return array<int, array{filename: string|null, content_type: string|null, size: int}>
+     */
+    private function attachmentMetadata(IMessage $message): array
+    {
+        $attachments = [];
+
+        foreach ($message->getAllAttachmentParts() as $part) {
+            $attachments[] = [
+                'filename' => $part->getFilename(),
+                'content_type' => $part->getContentType(),
+                'size' => strlen((string) $part->getContent()),
+            ];
+        }
+
+        return $attachments;
+    }
+}

--- a/app/Services/Providers/CloudflareInboundProvisioner.php
+++ b/app/Services/Providers/CloudflareInboundProvisioner.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\Providers;
+
+use App\Models\Domain;
+use App\Models\Source;
+use App\Services\CloudflareApiClient;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Turns on inbound email for a domain with zero manual Cloudflare steps:
+ * uploads the passthrough Worker, enables Email Routing on the zone, and
+ * points the catch-all rule at the Worker. Failures throw with the exact
+ * missing piece plus manual instructions, mirroring how automatic domain
+ * onboarding degrades on the sending side.
+ */
+class CloudflareInboundProvisioner
+{
+    public const WORKER_NAME = 'larasend-inbound';
+
+    public function __construct(private CloudflareApiClient $apiClient) {}
+
+    public function enable(Source $source, Domain $domain): void
+    {
+        $zone = $this->apiClient->findZone($source, $domain->domain);
+
+        if ($zone === null) {
+            throw new RuntimeException(
+                "No Cloudflare zone found for \"{$domain->domain}\". The domain must use Cloudflare DNS on the account the API token belongs to.",
+            );
+        }
+
+        try {
+            $this->apiClient->uploadWorker($source, self::WORKER_NAME, $this->workerCode(), [
+                'LARASEND_INBOUND_URL' => route('webhooks.inbound.cloudflare', $source->webhook_token),
+            ]);
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                'Could not deploy the inbound Worker: '.$exception->getMessage()
+                    .' Add the "Workers Scripts: Edit" permission to the API token, or deploy the Worker manually with wrangler.',
+                previous: $exception,
+            );
+        }
+
+        try {
+            $this->apiClient->enableEmailRouting($source, $zone['id']);
+            $this->apiClient->routeCatchAllToWorker($source, $zone['id'], self::WORKER_NAME);
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                'Deployed the Worker but could not configure Email Routing: '.$exception->getMessage()
+                    .' Add the "Email Routing Rules: Edit" permission to the API token, or point a routing rule at the "'.self::WORKER_NAME.'" Worker in the Cloudflare dashboard.',
+                previous: $exception,
+            );
+        }
+
+        $domain->forceFill(['inbound_enabled_at' => now()])->save();
+    }
+
+    public function workerCode(): string
+    {
+        return File::get(resource_path('cloudflare/inbound-email-worker.js'));
+    }
+}

--- a/app/Services/Providers/CloudflareInboundProvisioner.php
+++ b/app/Services/Providers/CloudflareInboundProvisioner.php
@@ -5,6 +5,7 @@ namespace App\Services\Providers;
 use App\Models\Domain;
 use App\Models\Source;
 use App\Services\CloudflareApiClient;
+use App\Services\DnsRecordVerifier;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
 use Throwable;
@@ -20,7 +21,19 @@ class CloudflareInboundProvisioner
 {
     public const WORKER_NAME = 'larasend-inbound';
 
-    public function __construct(private CloudflareApiClient $apiClient) {}
+    /**
+     * The MX records Cloudflare Email Routing expects at the zone apex.
+     */
+    private const ROUTING_MX = [
+        ['priority' => 20, 'target' => 'route1.mx.cloudflare.net'],
+        ['priority' => 59, 'target' => 'route2.mx.cloudflare.net'],
+        ['priority' => 99, 'target' => 'route3.mx.cloudflare.net'],
+    ];
+
+    public function __construct(
+        private CloudflareApiClient $apiClient,
+        private DnsRecordVerifier $dnsVerifier,
+    ) {}
 
     public function enable(Source $source, Domain $domain): void
     {
@@ -45,7 +58,6 @@ class CloudflareInboundProvisioner
         }
 
         try {
-            $this->apiClient->enableEmailRouting($source, $zone['id']);
             $this->apiClient->routeCatchAllToWorker($source, $zone['id'], self::WORKER_NAME);
         } catch (Throwable $exception) {
             throw new RuntimeException(
@@ -55,7 +67,56 @@ class CloudflareInboundProvisioner
             );
         }
 
+        $this->ensureRoutingDns($source, $zone['id'], $zone['name']);
+
         $domain->forceFill(['inbound_enabled_at' => now()])->save();
+    }
+
+    /**
+     * Delivery needs the routing MX records at the zone apex. The explicit
+     * enable endpoint is gated by a settings-level permission most tokens
+     * lack, so it is best-effort only; when the MX records are still missing
+     * afterwards they are published directly via DNS (which the token can
+     * already edit), and only an unresolvable state throws.
+     */
+    private function ensureRoutingDns(Source $source, string $zoneId, string $zoneName): void
+    {
+        try {
+            $this->apiClient->enableEmailRouting($source, $zoneId);
+        } catch (Throwable $exception) {
+            report($exception);
+        }
+
+        if ($this->routingMxPresent($zoneName)) {
+            return;
+        }
+
+        try {
+            $this->apiClient->ensureDnsRecords($source, $zoneId, collect(self::ROUTING_MX)
+                ->map(fn (array $mx): array => [
+                    'type' => 'MX',
+                    'name' => $zoneName,
+                    'content' => $mx['target'],
+                    'priority' => $mx['priority'],
+                ])
+                ->all());
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                'The routing rule is configured, but the zone apex has no Email Routing MX records and they could not be created: '
+                    .$exception->getMessage()
+                    .' Enable Email Routing on the zone in the Cloudflare dashboard (Compute & AI > Email Service > Email Routing) to finish setup.',
+                previous: $exception,
+            );
+        }
+    }
+
+    private function routingMxPresent(string $zoneName): bool
+    {
+        return $this->dnsVerifier->matches([
+            'type' => 'MX',
+            'name' => $zoneName,
+            'value' => 'route1.mx.cloudflare.net',
+        ]);
     }
 
     public function workerCode(): string

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "laravel/fortify": "^1.34",
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
-        "laravel/wayfinder": "^0.1.14"
+        "laravel/wayfinder": "^0.1.14",
+        "zbateson/mail-mime-parser": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a79858654fd66eccbb3bffa4a40729a8",
+    "content-hash": "0db9cbb286a28761d0270f911fbfc045",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3072,6 +3072,134 @@
             "time": "2025-09-24T15:06:41+00:00"
         },
         {
+            "name": "php-di/invoker",
+            "version": "2.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/Invoker.git",
+                "reference": "3c1ddfdef181431fbc4be83378f6d036d59e81e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/3c1ddfdef181431fbc4be83378f6d036d59e81e1",
+                "reference": "3c1ddfdef181431fbc4be83378f6d036d59e81e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "psr/container": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "mnapoli/hard-mode": "~0.3.0",
+                "phpunit/phpunit": "^9.0 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Generic and extensible callable invoker",
+            "homepage": "https://github.com/PHP-DI/Invoker",
+            "keywords": [
+                "callable",
+                "dependency",
+                "dependency-injection",
+                "injection",
+                "invoke",
+                "invoker"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-DI/Invoker/issues",
+                "source": "https://github.com/PHP-DI/Invoker/tree/2.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-30T10:22:22+00:00"
+        },
+        {
+            "name": "php-di/php-di",
+            "version": "7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/PHP-DI.git",
+                "reference": "f88054cc052e40dbe7b383c8817c19442d480352"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/PHP-DI/zipball/f88054cc052e40dbe7b383c8817c19442d480352",
+                "reference": "f88054cc052e40dbe7b383c8817c19442d480352",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/serializable-closure": "^1.0 || ^2.0",
+                "php": ">=8.0",
+                "php-di/invoker": "^2.0",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "friendsofphp/proxy-manager-lts": "^1",
+                "mnapoli/phpunit-easymock": "^1.3",
+                "phpunit/phpunit": "^9.6 || ^10 || ^11",
+                "vimeo/psalm": "^5|^6"
+            },
+            "suggest": {
+                "friendsofphp/proxy-manager-lts": "Install it if you want to use lazy injection (version ^1)"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "DI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The dependency injection container for humans",
+            "homepage": "https://php-di.org/",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interop",
+                "dependency injection",
+                "di",
+                "ioc",
+                "psr11"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-DI/PHP-DI/issues",
+                "source": "https://github.com/PHP-DI/PHP-DI/tree/7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/php-di/php-di",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-16T11:10:48+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "2.2.0",
             "source": {
@@ -5324,6 +5452,90 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/2c5729fd241b4b22f6e4b436bc3354a4f262df57",
+                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7621,6 +7833,214 @@
                 "source": "https://github.com/webmozarts/assert/tree/2.3.0"
             },
             "time": "2026-04-11T10:33:05+00:00"
+        },
+        {
+            "name": "zbateson/mail-mime-parser",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/mail-mime-parser.git",
+                "reference": "0f268ceb5a60738f082da6881414ed2c8e0bb088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/0f268ceb5a60738f082da6881414ed2c8e0bb088",
+                "reference": "0f268ceb5a60738f082da6881414ed2c8e0bb088",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.5",
+                "php": ">=8.1",
+                "php-di/php-di": "^6.0|^7.0",
+                "psr/log": "^1|^2|^3",
+                "zbateson/mb-wrapper": "^2.0 || ^3.0",
+                "zbateson/stream-decorators": "^2.1 || ^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "monolog/monolog": "^2|^3",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^10.5"
+            },
+            "suggest": {
+                "ext-iconv": "For best support/performance",
+                "ext-mbstring": "For best support/performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\MailMimeParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/zbateson/mail-mime-parser/graphs/contributors"
+                }
+            ],
+            "description": "MIME email message parser",
+            "homepage": "https://mail-mime-parser.org",
+            "keywords": [
+                "MimeMailParser",
+                "email",
+                "mail",
+                "mailparse",
+                "mime",
+                "mimeparse",
+                "parser",
+                "php-imap"
+            ],
+            "support": {
+                "docs": "https://mail-mime-parser.org/#usage-guide",
+                "issues": "https://github.com/zbateson/mail-mime-parser/issues",
+                "source": "https://github.com/zbateson/mail-mime-parser"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-24T03:13:44+00:00"
+        },
+        {
+            "name": "zbateson/mb-wrapper",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/mb-wrapper.git",
+                "reference": "36dd227ed698d9f5fe995ea75dbcc594a2d880bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/mb-wrapper/zipball/36dd227ed698d9f5fe995ea75dbcc594a2d880bb",
+                "reference": "36dd227ed698d9f5fe995ea75dbcc594a2d880bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-iconv": "^1.9",
+                "symfony/polyfill-mbstring": "^1.9"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^10.0|^11.0"
+            },
+            "suggest": {
+                "ext-iconv": "For best support/performance",
+                "ext-mbstring": "For best support/performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\MbWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                }
+            ],
+            "description": "Wrapper for mbstring with fallback to iconv for encoding conversion and string manipulation",
+            "keywords": [
+                "charset",
+                "encoding",
+                "http",
+                "iconv",
+                "mail",
+                "mb",
+                "mb_convert_encoding",
+                "mbstring",
+                "mime",
+                "multibyte",
+                "string"
+            ],
+            "support": {
+                "issues": "https://github.com/zbateson/mb-wrapper/issues",
+                "source": "https://github.com/zbateson/mb-wrapper/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-24T03:02:00+00:00"
+        },
+        {
+            "name": "zbateson/stream-decorators",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/stream-decorators.git",
+                "reference": "093a898753e95e0063d0ca67c04b7b2619742ae9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/stream-decorators/zipball/093a898753e95e0063d0ca67c04b7b2619742ae9",
+                "reference": "093a898753e95e0063d0ca67c04b7b2619742ae9",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.5",
+                "php": ">=8.1",
+                "zbateson/mb-wrapper": "^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^10.0 || ^11.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\StreamDecorators\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                }
+            ],
+            "description": "PHP psr7 stream decorators for mime message part streams",
+            "keywords": [
+                "base64",
+                "charset",
+                "decorators",
+                "mail",
+                "mime",
+                "psr7",
+                "quoted-printable",
+                "stream",
+                "uuencode"
+            ],
+            "support": {
+                "issues": "https://github.com/zbateson/stream-decorators/issues",
+                "source": "https://github.com/zbateson/stream-decorators/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-24T02:55:37+00:00"
         }
     ],
     "packages-dev": [

--- a/database/migrations/2026_07_10_180957_create_inbound_emails_table.php
+++ b/database/migrations/2026_07_10_180957_create_inbound_emails_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('inbound_emails', function (Blueprint $table) {
+            $table->id();
+            $table->string('public_id')->unique();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('source_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('from_email');
+            $table->string('from_name')->nullable();
+            $table->string('to_email');
+            $table->string('subject')->nullable();
+            $table->longText('text')->nullable();
+            $table->longText('html')->nullable();
+            $table->json('headers')->nullable();
+            $table->json('attachments')->nullable();
+            $table->string('message_id')->nullable()->index();
+            $table->string('in_reply_to')->nullable();
+            $table->string('mime_disk')->default('local');
+            $table->string('mime_path');
+            $table->unsignedBigInteger('mime_size')->default(0);
+            $table->timestamp('received_at');
+            $table->timestamps();
+
+            $table->index(['project_id', 'received_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inbound_emails');
+    }
+};

--- a/database/migrations/2026_07_10_180958_add_inbound_enabled_at_to_domains_table.php
+++ b/database/migrations/2026_07_10_180958_add_inbound_enabled_at_to_domains_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('domains', function (Blueprint $table) {
+            $table->timestamp('inbound_enabled_at')->nullable()->after('verified_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('domains', function (Blueprint $table) {
+            $table->dropColumn('inbound_enabled_at');
+        });
+    }
+};

--- a/resources/cloudflare/inbound-email-worker.js
+++ b/resources/cloudflare/inbound-email-worker.js
@@ -1,0 +1,37 @@
+/**
+ * Larasend inbound email worker.
+ *
+ * Cloudflare Email Routing invokes this handler for messages matching the
+ * routing rule and it forwards the raw MIME to Larasend for parsing and
+ * storage. Deployed automatically by Larasend; LARASEND_INBOUND_URL is set
+ * as a plain-text binding at upload time.
+ *
+ * Throwing on failure defers the message so the sending server retries —
+ * emails are never silently dropped when Larasend is unreachable.
+ */
+export default {
+  async email(message, env) {
+    const buffer = await new Response(message.raw).arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+
+    let binary = "";
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+    }
+
+    const response = await fetch(env.LARASEND_INBOUND_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: message.from,
+        to: message.to,
+        raw: btoa(binary),
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Larasend inbound endpoint responded ${response.status}`);
+    }
+  },
+};

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -30,6 +30,7 @@ import {
     watch,
 } from 'vue';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
+import { Toaster } from '@/components/ui/sonner';
 import { getInitials } from '@/composables/useInitials';
 
 type Metric = {
@@ -302,6 +303,7 @@ const props = defineProps<{
         created_at: string;
     }[];
     newApiKey: string | null;
+    inboundError: string | null;
     setup: {
         webhook_url: string | null;
         next_step: {
@@ -4238,6 +4240,15 @@ function recipientTitle(email: EmailRow): string | undefined {
                                     class="rounded-md bg-emerald-500/12 px-2.5 py-1 font-mono text-xs text-emerald-400"
                                     >enabled</span
                                 >
+                                <div
+                                    v-if="
+                                        inboundError &&
+                                        !selectedIdentity.inbound_enabled_at
+                                    "
+                                    class="w-full rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-950 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-100"
+                                >
+                                    {{ inboundError }}
+                                </div>
                                 <button
                                     v-else-if="workspace.can_manage_domains"
                                     type="button"
@@ -6041,4 +6052,5 @@ function recipientTitle(email: EmailRow): string | undefined {
             </section>
         </div>
     </div>
+    <Toaster />
 </template>

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -9,6 +9,7 @@ import {
     Cloud,
     Copy,
     FileText,
+    Inbox,
     KeyRound,
     MailCheck,
     Pencil,
@@ -255,6 +256,24 @@ const props = defineProps<{
             | { type: string; name: string; value: string; status?: string }[]
             | null;
         verified_at: string | null;
+        inbound_enabled_at: string | null;
+    }[];
+    inboundEmails: {
+        public_id: string;
+        from_email: string;
+        from_name: string | null;
+        to_email: string;
+        subject: string | null;
+        text: string | null;
+        html: string | null;
+        attachments:
+            | {
+                  filename: string | null;
+                  content_type: string | null;
+                  size: number;
+              }[]
+            | null;
+        received_at: string;
     }[];
     templates: {
         slug: string;
@@ -380,7 +399,7 @@ const sourceForm = reactive({
     aws_session_token: '',
     retention_days: props.source?.retention_days ?? 90,
 });
-const domainForm = reactive({ domain: '' });
+const domainForm = useForm({ domain: '' });
 const templateForm = reactive({
     slug: '',
     name: '',
@@ -401,6 +420,7 @@ const webhookEventOptions = [
     'open',
     'click',
     'suppress',
+    'inbound.received',
 ];
 const webhookForm = reactive({
     url: '',
@@ -859,6 +879,13 @@ const navItems = computed(() => [
         count: props.sidebarCounts.sent,
     },
     {
+        label: 'Inbound',
+        section: 'inbound',
+        href: sectionHref('inbound'),
+        icon: Inbox,
+        count: props.sidebarCounts.inbound,
+    },
+    {
         label: 'Bounces',
         section: 'bounces',
         href: sectionHref('bounces'),
@@ -1058,11 +1085,37 @@ const identityStats = computed(() => {
         },
     ];
 });
+const selectedInboundId = ref<string | null>(null);
+const selectedInbound = computed(
+    () =>
+        props.inboundEmails.find(
+            (email) => email.public_id === selectedInboundId.value,
+        ) ??
+        props.inboundEmails[0] ??
+        null,
+);
+const enablingInboundDomainId = ref<number | null>(null);
+
+function enableInbound(domainId: number): void {
+    enablingInboundDomainId.value = domainId;
+    router.post(
+        projectAction(`/domains/${domainId}/inbound`),
+        {},
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                enablingInboundDomainId.value = null;
+            },
+        },
+    );
+}
+
 const pageTitle = computed(() => {
     return (
         {
             activity: 'Activity',
             sent: 'Sent',
+            inbound: 'Inbound',
             bounces: 'Bounces',
             complaints: 'Complaints',
             suppressions: 'Suppressions',
@@ -1110,12 +1163,23 @@ function syncQuotaIfStale(): void {
     syncQuota(true);
 }
 
+function normalizeIdentityDomain(value: string): string {
+    const identity = value.trim();
+    const domain = identity.includes('@')
+        ? identity.slice(identity.lastIndexOf('@') + 1)
+        : identity;
+
+    return domain.replace(/^[<\s]+|[>\s.,;]+$/g, '').toLowerCase();
+}
+
 function addDomain(): void {
-    router.post(projectAction('/domains'), domainForm, {
+    domainForm.domain = normalizeIdentityDomain(domainForm.domain);
+
+    domainForm.post(projectAction('/domains'), {
         preserveScroll: true,
         onSuccess: () => {
             selectedIdentityDomain.value = domainForm.domain;
-            domainForm.domain = '';
+            domainForm.reset();
             showNewIdentity.value = false;
         },
     });
@@ -3893,18 +3957,31 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 @submit.prevent="addDomain"
                             >
                                 <label class="grid gap-2 text-sm">
-                                    <span class="text-zinc-500">Domain</span>
+                                    <span class="text-zinc-500"
+                                        >Email or domain</span
+                                    >
                                     <input
                                         v-model="domainForm.domain"
                                         class="rounded-md border border-zinc-200 bg-white px-3 py-2 dark:border-zinc-800 dark:bg-[#101111]"
-                                        placeholder="mail.example.com"
+                                        placeholder="founder@example.com"
                                         required
                                     />
+                                    <span
+                                        v-if="domainForm.errors.domain"
+                                        class="text-xs font-medium text-red-600 dark:text-red-400"
+                                    >
+                                        {{ domainForm.errors.domain }}
+                                    </span>
                                 </label>
                                 <button
                                     class="w-fit rounded-lg bg-teal-400 px-3 py-2 text-sm font-bold text-zinc-950"
+                                    :disabled="domainForm.processing"
                                 >
-                                    Create identity
+                                    {{
+                                        domainForm.processing
+                                            ? 'Creating...'
+                                            : 'Create identity'
+                                    }}
                                 </button>
                             </form>
                             <button
@@ -4139,6 +4216,45 @@ function recipientTitle(email: EmailRow): string | undefined {
                                         </p>
                                     </div>
                                 </div>
+                            </div>
+
+                            <div
+                                v-if="isCloudflare"
+                                class="mt-5 flex flex-wrap items-center gap-3 rounded-lg border border-zinc-200 p-4 dark:border-zinc-800"
+                            >
+                                <Inbox class="size-4 text-teal-500" />
+                                <div class="min-w-0 flex-1">
+                                    <h3 class="font-semibold">Receive email</h3>
+                                    <p class="mt-0.5 text-sm text-zinc-500">
+                                        {{
+                                            selectedIdentity.inbound_enabled_at
+                                                ? 'Inbound is on: mail to any address on this zone lands in the Inbound section and fires inbound.received webhooks.'
+                                                : 'Larasend deploys a Cloudflare Worker and routing rule so mail to this zone lands in your Inbound section.'
+                                        }}
+                                    </p>
+                                </div>
+                                <span
+                                    v-if="selectedIdentity.inbound_enabled_at"
+                                    class="rounded-md bg-emerald-500/12 px-2.5 py-1 font-mono text-xs text-emerald-400"
+                                    >enabled</span
+                                >
+                                <button
+                                    v-else-if="workspace.can_manage_domains"
+                                    type="button"
+                                    class="rounded-lg bg-teal-400 px-3 py-2 text-sm font-bold text-zinc-950 disabled:cursor-wait disabled:opacity-60"
+                                    :disabled="
+                                        enablingInboundDomainId ===
+                                        selectedIdentity.id
+                                    "
+                                    @click="enableInbound(selectedIdentity.id)"
+                                >
+                                    {{
+                                        enablingInboundDomainId ===
+                                        selectedIdentity.id
+                                            ? 'Enabling...'
+                                            : 'Enable receiving'
+                                    }}
+                                </button>
                             </div>
 
                             <div class="mt-5">
@@ -4576,6 +4692,143 @@ function recipientTitle(email: EmailRow): string | undefined {
                                     </button>
                                 </form>
                             </section>
+                        </section>
+                    </div>
+
+                    <div
+                        v-else-if="section === 'inbound'"
+                        class="grid min-h-0 gap-0 overflow-hidden rounded-lg border border-zinc-200 bg-white lg:grid-cols-[360px_minmax(0,1fr)] dark:border-zinc-800 dark:bg-[#090a0a]"
+                    >
+                        <aside
+                            class="min-h-0 overflow-auto border-r border-zinc-200 dark:border-zinc-800"
+                        >
+                            <div
+                                class="border-b border-zinc-200 p-4 font-sans dark:border-zinc-800"
+                            >
+                                <h2 class="font-semibold">
+                                    Inbound
+                                    <span class="text-zinc-500">{{
+                                        inboundEmails.length
+                                    }}</span>
+                                </h2>
+                                <p class="mt-1 text-sm text-zinc-500">
+                                    Email received for your domains. Enable
+                                    receiving per domain under Domains.
+                                </p>
+                            </div>
+                            <div
+                                v-if="!inboundEmails.length"
+                                class="p-4 font-sans text-sm text-zinc-500"
+                            >
+                                Nothing received yet. Enable receiving on a
+                                domain, then send an email to any address on it.
+                            </div>
+                            <button
+                                v-for="email in inboundEmails"
+                                :key="email.public_id"
+                                type="button"
+                                class="grid w-full gap-1 border-b border-zinc-200 p-4 text-left font-sans transition hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-[#141618]"
+                                :class="
+                                    selectedInbound?.public_id ===
+                                    email.public_id
+                                        ? 'bg-teal-50 dark:bg-teal-400/10'
+                                        : ''
+                                "
+                                @click="selectedInboundId = email.public_id"
+                            >
+                                <div
+                                    class="flex items-baseline justify-between gap-2"
+                                >
+                                    <span
+                                        class="truncate text-sm font-semibold"
+                                    >
+                                        {{
+                                            email.from_name || email.from_email
+                                        }}
+                                    </span>
+                                    <span
+                                        class="shrink-0 font-mono text-[11px] text-zinc-500"
+                                    >
+                                        {{ relativeTime(email.received_at) }}
+                                    </span>
+                                </div>
+                                <div class="truncate text-sm">
+                                    {{ email.subject || '(no subject)' }}
+                                </div>
+                                <div
+                                    class="truncate font-mono text-[11px] text-zinc-500"
+                                >
+                                    to {{ email.to_email }}
+                                </div>
+                            </button>
+                        </aside>
+                        <section
+                            v-if="selectedInbound"
+                            class="grid min-h-0 content-start gap-4 overflow-auto p-5 font-sans"
+                        >
+                            <div>
+                                <h2 class="text-lg font-semibold">
+                                    {{
+                                        selectedInbound.subject ||
+                                        '(no subject)'
+                                    }}
+                                </h2>
+                                <div
+                                    class="mt-1 grid gap-0.5 font-mono text-xs text-zinc-500"
+                                >
+                                    <span>
+                                        from
+                                        {{
+                                            selectedInbound.from_name
+                                                ? `${selectedInbound.from_name} <${selectedInbound.from_email}>`
+                                                : selectedInbound.from_email
+                                        }}
+                                    </span>
+                                    <span
+                                        >to {{ selectedInbound.to_email }}</span
+                                    >
+                                    <span
+                                        v-if="
+                                            selectedInbound.attachments?.length
+                                        "
+                                    >
+                                        {{ selectedInbound.attachments.length }}
+                                        attachment{{
+                                            selectedInbound.attachments
+                                                .length === 1
+                                                ? ''
+                                                : 's'
+                                        }}
+                                        ·
+                                        {{
+                                            selectedInbound.attachments
+                                                .map((a) => a.filename)
+                                                .filter(Boolean)
+                                                .join(', ')
+                                        }}
+                                    </span>
+                                </div>
+                            </div>
+                            <iframe
+                                v-if="selectedInbound.html"
+                                :srcdoc="selectedInbound.html"
+                                sandbox=""
+                                class="h-[60vh] w-full rounded-lg border border-zinc-200 bg-white dark:border-zinc-800"
+                                title="Inbound email preview"
+                            />
+                            <pre
+                                v-else
+                                class="rounded-lg border border-zinc-200 bg-zinc-50 p-4 font-mono text-xs whitespace-pre-wrap text-zinc-800 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-200"
+                                >{{
+                                    selectedInbound.text || '(empty body)'
+                                }}</pre
+                            >
+                        </section>
+                        <section
+                            v-else
+                            class="grid place-items-center p-10 font-sans text-sm text-zinc-500"
+                        >
+                            Select an email to preview it.
                         </section>
                     </div>
 

--- a/resources/js/pages/Onboarding.vue
+++ b/resources/js/pages/Onboarding.vue
@@ -14,6 +14,7 @@ import {
     Webhook,
 } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
+import { Toaster } from '@/components/ui/sonner';
 
 type CredentialMode =
     | 'instance_role'
@@ -1218,4 +1219,5 @@ function submit(): void {
             </form>
         </div>
     </main>
+    <Toaster />
 </template>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\EmailController;
+use App\Http\Controllers\Webhooks\CloudflareInboundController;
 use App\Http\Controllers\Webhooks\SesWebhookController;
 use App\Http\Middleware\AuthenticateLarasendApiKey;
 use Illuminate\Support\Facades\Route;
@@ -14,3 +15,7 @@ Route::middleware(AuthenticateLarasendApiKey::class)->group(function () {
 Route::post('webhooks/ses/{token}', SesWebhookController::class)
     ->middleware('throttle:120,1')
     ->name('webhooks.ses');
+
+Route::post('webhooks/inbound/cloudflare/{token}', CloudflareInboundController::class)
+    ->middleware('throttle:240,1')
+    ->name('webhooks.inbound.cloudflare');

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('source/quota', [DashboardActionController::class, 'syncSourceQuota'])->name('source.quota.sync');
         Route::post('domains', [DashboardActionController::class, 'storeDomain'])->name('domains.store');
         Route::post('domains/{domain}/check-dns', [DashboardActionController::class, 'checkProjectDomain'])->name('domains.check-dns');
+        Route::post('domains/{domain}/inbound', [DashboardActionController::class, 'enableProjectDomainInbound'])->name('domains.inbound');
         Route::delete('domains/{domain}', [DashboardActionController::class, 'destroyProjectDomain'])->name('domains.destroy');
         Route::post('templates', [DashboardActionController::class, 'storeTemplate'])->name('templates.store');
         Route::post('api-keys', [DashboardActionController::class, 'storeApiKey'])->name('api-keys.store');
@@ -57,13 +58,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('bounces/retry-soft', [DashboardActionController::class, 'retrySoftBounces'])->name('bounces.retry-soft');
         Route::post('emails/{email:public_id}/resend', [DashboardActionController::class, 'resendProjectEmail'])->name('emails.resend');
         Route::get('{section}', ActivityController::class)
-            ->where('section', 'activity|sent|bounces|complaints|suppressions|identities|templates|webhooks|api-keys|send|setup|projects')
+            ->where('section', 'activity|sent|inbound|bounces|complaints|suppressions|identities|templates|webhooks|api-keys|send|setup|projects')
             ->name('section');
     });
 
     Route::get('activity', ActivityController::class)->defaults('section', 'activity')->name('activity');
     Route::get('activity/export', ActivityExportController::class)->name('activity.export');
     Route::get('sent', ActivityController::class)->defaults('section', 'sent')->name('sent');
+    Route::get('inbound', ActivityController::class)->defaults('section', 'inbound')->name('inbound');
     Route::get('bounces', ActivityController::class)->defaults('section', 'bounces')->name('bounces');
     Route::get('complaints', ActivityController::class)->defaults('section', 'complaints')->name('complaints');
     Route::get('suppressions', ActivityController::class)->defaults('section', 'suppressions')->name('suppressions');
@@ -75,6 +77,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('setup', ActivityController::class)->defaults('section', 'setup')->name('setup');
     Route::post('domains', [DashboardActionController::class, 'storeDomain'])->name('domains.store');
     Route::post('domains/{domain}/check-dns', [DashboardActionController::class, 'checkDomain'])->name('domains.check-dns');
+    Route::post('domains/{domain}/inbound', [DashboardActionController::class, 'enableDomainInbound'])->name('domains.inbound');
     Route::delete('domains/{domain}', [DashboardActionController::class, 'destroyDomain'])->name('domains.destroy');
     Route::put('source', [DashboardActionController::class, 'updateSource'])->name('source.update');
     Route::post('templates', [DashboardActionController::class, 'storeTemplate'])->name('templates.store');

--- a/tests/Feature/DashboardActionsTest.php
+++ b/tests/Feature/DashboardActionsTest.php
@@ -167,6 +167,17 @@ it('uses existing ses identity details when aws says the domain already exist', 
         ->and($domain->dns_records[0]['value'])->toContain('existing123');
 });
 
+it('accepts an email address when creating a sending identity', function () {
+    $user = User::factory()->create();
+    $project = fakeSesIdentityCreation($user);
+
+    $this->actingAs($user)
+        ->post('/domains', ['domain' => 'Vijay@Mail.Example.COM'])
+        ->assertRedirect('/identities');
+
+    expect($project->domains()->where('domain', 'mail.example.com')->exists())->toBeTrue();
+});
+
 it('re-checks domain dns records and stores status results', function () {
     $user = User::factory()->create();
     fakeSesIdentityCreation($user);

--- a/tests/Feature/InboundEmailTest.php
+++ b/tests/Feature/InboundEmailTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Jobs\DeliverInboundWebhook;
+use App\Models\InboundEmail;
+use App\Models\Project;
+use App\Models\Source;
+use App\Models\User;
+use App\Models\WebhookEndpoint;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+
+function inboundProjectFixture(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::create(['owner_id' => $user->id, 'name' => 'Inbound Co', 'slug' => 'inbound-co']);
+    $workspace->users()->attach($user, ['role' => 'owner']);
+    $project = Project::create(['workspace_id' => $workspace->id, 'name' => 'postbox', 'slug' => 'postbox']);
+    $source = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Production',
+        'environment' => 'prod',
+        'provider' => 'cloudflare',
+        'cloudflare_api_token' => 'cf-test-token',
+        'cloudflare_account_id' => 'acc-inbound',
+        'default_from_email' => 'notifications@mail.example.com',
+        'webhook_token' => 'inbound-token-'.str()->random(8),
+    ]);
+
+    return [$user, $workspace, $project, $source];
+}
+
+function sampleInboundMime(): string
+{
+    return implode("\r\n", [
+        'From: Maya Lin <maya@customer.test>',
+        'To: support@example.com',
+        'Subject: Need help with my invoice',
+        'Message-ID: <origin-123@customer.test>',
+        'In-Reply-To: <thread-99@example.com>',
+        'MIME-Version: 1.0',
+        'Content-Type: multipart/alternative; boundary="BOUND"',
+        '',
+        '--BOUND',
+        'Content-Type: text/plain; charset=utf-8',
+        '',
+        'Hi, my invoice looks wrong.',
+        '--BOUND',
+        'Content-Type: text/html; charset=utf-8',
+        '',
+        '<p>Hi, my <strong>invoice</strong> looks wrong.</p>',
+        '--BOUND--',
+        '',
+    ]);
+}
+
+it('ingests inbound email posted by the cloudflare worker', function () {
+    [, $workspace, $project, $source] = inboundProjectFixture();
+
+    Queue::fake();
+
+    $this->postJson("/api/webhooks/inbound/cloudflare/{$source->webhook_token}", [
+        'from' => 'maya@customer.test',
+        'to' => 'support@example.com',
+        'raw' => base64_encode(sampleInboundMime()),
+    ])->assertStatus(202);
+
+    $inbound = InboundEmail::query()->firstOrFail();
+
+    expect($inbound->project_id)->toBe($project->id)
+        ->and($inbound->from_email)->toBe('maya@customer.test')
+        ->and($inbound->from_name)->toBe('Maya Lin')
+        ->and($inbound->to_email)->toBe('support@example.com')
+        ->and($inbound->subject)->toBe('Need help with my invoice')
+        ->and(trim((string) $inbound->text))->toBe('Hi, my invoice looks wrong.')
+        ->and($inbound->html)->toContain('<strong>invoice</strong>')
+        ->and($inbound->message_id)->toBe('origin-123@customer.test')
+        ->and($inbound->in_reply_to)->toBe('thread-99@example.com')
+        ->and($inbound->mime_size)->toBeGreaterThan(0);
+
+    Queue::assertPushed(DeliverInboundWebhook::class);
+});
+
+it('rejects inbound posts with an unknown token or wrong provider', function () {
+    [, , , $source] = inboundProjectFixture();
+    $source->forceFill(['provider' => 'ses'])->save();
+
+    $this->postJson("/api/webhooks/inbound/cloudflare/{$source->webhook_token}", [
+        'from' => 'a@b.test',
+        'to' => 'c@d.test',
+        'raw' => base64_encode('hello'),
+    ])->assertNotFound();
+
+    $this->postJson('/api/webhooks/inbound/cloudflare/not-a-token', [
+        'from' => 'a@b.test',
+        'to' => 'c@d.test',
+        'raw' => base64_encode('hello'),
+    ])->assertNotFound();
+
+    expect(InboundEmail::query()->count())->toBe(0);
+});
+
+it('rejects invalid base64 payloads', function () {
+    [, , , $source] = inboundProjectFixture();
+
+    $this->postJson("/api/webhooks/inbound/cloudflare/{$source->webhook_token}", [
+        'from' => 'a@b.test',
+        'to' => 'c@d.test',
+        'raw' => 'not!!valid@@base64',
+    ])->assertStatus(422);
+});
+
+it('fans inbound emails out to subscribed webhook endpoints with signatures', function () {
+    [, , $project, $source] = inboundProjectFixture();
+
+    $issued = WebhookEndpoint::issue($project, 'https://customer.test/hooks', ['inbound.received']);
+    WebhookEndpoint::issue($project, 'https://customer.test/other', ['delivery']);
+
+    Http::fake(['https://customer.test/*' => Http::response(['ok' => true])]);
+
+    $this->postJson("/api/webhooks/inbound/cloudflare/{$source->webhook_token}", [
+        'from' => 'maya@customer.test',
+        'to' => 'support@example.com',
+        'raw' => base64_encode(sampleInboundMime()),
+    ])->assertStatus(202);
+
+    Http::assertSentCount(1);
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://customer.test/hooks'
+            && $request->hasHeader('Larasend-Event-Type', 'inbound.received')
+            && str_contains($request->header('Larasend-Signature')[0] ?? '', 'v1=')
+            && ($request->data()['data']['inbound_email']['subject'] ?? null) === 'Need help with my invoice';
+    });
+
+    expect($issued['endpoint']->fresh()->last_delivered_at)->not->toBeNull();
+});

--- a/tests/Feature/InboundProvisioningTest.php
+++ b/tests/Feature/InboundProvisioningTest.php
@@ -43,6 +43,10 @@ it('provisions cloudflare inbound end to end: worker, routing, catch-all', funct
         'https://api.cloudflare.com/client/v4/accounts/acc-prov/workers/scripts/larasend-inbound' => Http::response(['success' => true, 'result' => ['id' => 'larasend-inbound']]),
         'https://api.cloudflare.com/client/v4/zones/zone-9/email/routing/enable' => Http::response(['success' => true, 'result' => ['enabled' => true]]),
         'https://api.cloudflare.com/client/v4/zones/zone-9/email/routing/rules/catch_all' => Http::response(['success' => true, 'result' => ['enabled' => true]]),
+        'https://cloudflare-dns.com/*' => Http::response([
+            'Status' => 0,
+            'Answer' => [['name' => 'example.com', 'type' => 15, 'data' => '20 route1.mx.cloudflare.net.']],
+        ]),
     ]);
 
     $this->actingAs($user)
@@ -107,4 +111,34 @@ it('refuses to enable inbound for non-cloudflare sources', function () {
     Http::assertNothingSent();
 
     expect($domain->fresh()->inbound_enabled_at)->toBeNull();
+});
+
+it('publishes routing mx records directly when the enable endpoint is forbidden', function () {
+    [$user, $project, $source, $domain] = provisioningFixture();
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/zones?*' => Http::response([
+            'success' => true,
+            'result' => [['id' => 'zone-9', 'name' => 'example.com', 'account' => ['id' => 'acc-prov', 'name' => 'Prov']]],
+        ]),
+        'https://api.cloudflare.com/client/v4/accounts/acc-prov/workers/scripts/larasend-inbound' => Http::response(['success' => true, 'result' => ['id' => 'larasend-inbound']]),
+        'https://api.cloudflare.com/client/v4/zones/zone-9/email/routing/rules/catch_all' => Http::response(['success' => true, 'result' => ['enabled' => true]]),
+        'https://api.cloudflare.com/client/v4/zones/zone-9/email/routing/enable' => Http::response([
+            'success' => false,
+            'errors' => [['code' => 10000, 'message' => 'Authentication error']],
+        ], 403),
+        'https://cloudflare-dns.com/*' => Http::response(['Status' => 3, 'Answer' => []]),
+        'https://dns.google/*' => Http::response(['Status' => 3, 'Answer' => []]),
+        'https://api.cloudflare.com/client/v4/zones/zone-9/dns_records' => Http::response(['success' => true, 'result' => ['id' => 'rec-1']]),
+    ]);
+
+    $this->actingAs($user)
+        ->post("/projects/{$project->slug}/domains/{$domain->id}/inbound")
+        ->assertRedirect("/projects/{$project->slug}/identities");
+
+    expect($domain->fresh()->inbound_enabled_at)->not->toBeNull();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/zones/zone-9/dns_records')
+        && ($request->data()['type'] ?? null) === 'MX'
+        && str_contains((string) ($request->data()['content'] ?? ''), 'mx.cloudflare.net'));
 });

--- a/tests/Feature/InboundProvisioningTest.php
+++ b/tests/Feature/InboundProvisioningTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\Project;
+use App\Models\Source;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Http;
+
+function provisioningFixture(): array
+{
+    $user = User::factory()->create();
+    $workspace = Workspace::create(['owner_id' => $user->id, 'name' => 'Prov Co', 'slug' => 'prov-co']);
+    $workspace->users()->attach($user, ['role' => 'owner']);
+    $project = Project::create(['workspace_id' => $workspace->id, 'name' => 'provbox', 'slug' => 'provbox']);
+    $source = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Production',
+        'environment' => 'prod',
+        'provider' => 'cloudflare',
+        'cloudflare_api_token' => 'cf-test-token',
+        'cloudflare_account_id' => 'acc-prov',
+        'default_from_email' => 'notifications@mail.example.com',
+        'webhook_token' => 'prov-token-'.str()->random(8),
+    ]);
+    $domain = $project->domains()->create([
+        'domain' => 'mail.example.com',
+        'status' => 'verified',
+        'dns_records' => [],
+        'verified_at' => now(),
+    ]);
+
+    return [$user, $project, $source, $domain];
+}
+
+it('provisions cloudflare inbound end to end: worker, routing, catch-all', function () {
+    [$user, $project, $source, $domain] = provisioningFixture();
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/zones?*' => Http::response([
+            'success' => true,
+            'result' => [['id' => 'zone-9', 'name' => 'example.com', 'account' => ['id' => 'acc-prov', 'name' => 'Prov']]],
+        ]),
+        'https://api.cloudflare.com/client/v4/accounts/acc-prov/workers/scripts/larasend-inbound' => Http::response(['success' => true, 'result' => ['id' => 'larasend-inbound']]),
+        'https://api.cloudflare.com/client/v4/zones/zone-9/email/routing/enable' => Http::response(['success' => true, 'result' => ['enabled' => true]]),
+        'https://api.cloudflare.com/client/v4/zones/zone-9/email/routing/rules/catch_all' => Http::response(['success' => true, 'result' => ['enabled' => true]]),
+    ]);
+
+    $this->actingAs($user)
+        ->post("/projects/{$project->slug}/domains/{$domain->id}/inbound")
+        ->assertRedirect("/projects/{$project->slug}/identities");
+
+    expect($domain->fresh()->inbound_enabled_at)->not->toBeNull();
+
+    Http::assertSent(function ($request) use ($source) {
+        if (! str_contains($request->url(), '/workers/scripts/larasend-inbound')) {
+            return false;
+        }
+
+        $body = (string) $request->body();
+
+        return str_contains($body, 'LARASEND_INBOUND_URL')
+            && str_contains($body, $source->webhook_token)
+            && str_contains($body, 'async email(message, env)');
+    });
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/email/routing/rules/catch_all')
+        && ($request->data()['actions'][0]['type'] ?? null) === 'worker'
+        && ($request->data()['actions'][0]['value'][0] ?? null) === 'larasend-inbound');
+});
+
+it('surfaces the missing worker permission with manual instructions', function () {
+    [$user, $project, $source, $domain] = provisioningFixture();
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/zones?*' => Http::response([
+            'success' => true,
+            'result' => [['id' => 'zone-9', 'name' => 'example.com', 'account' => ['id' => 'acc-prov', 'name' => 'Prov']]],
+        ]),
+        'https://api.cloudflare.com/client/v4/accounts/acc-prov/workers/scripts/larasend-inbound' => Http::response([
+            'success' => false,
+            'errors' => [['code' => 10000, 'message' => 'Authentication error']],
+        ], 403),
+    ]);
+
+    $this->actingAs($user)
+        ->post("/projects/{$project->slug}/domains/{$domain->id}/inbound")
+        ->assertRedirect("/projects/{$project->slug}/identities");
+
+    $toast = session('inertia.flash_data')['toast'] ?? null;
+
+    expect($domain->fresh()->inbound_enabled_at)->toBeNull()
+        ->and($toast['type'])->toBe('error')
+        ->and($toast['message'])->toContain('Workers Scripts: Edit');
+});
+
+it('refuses to enable inbound for non-cloudflare sources', function () {
+    [$user, $project, $source, $domain] = provisioningFixture();
+    $source->forceFill(['provider' => 'ses'])->save();
+
+    Http::fake();
+
+    $this->actingAs($user)
+        ->post("/projects/{$project->slug}/domains/{$domain->id}/inbound")
+        ->assertRedirect("/projects/{$project->slug}/identities");
+
+    Http::assertNothingSent();
+
+    expect($domain->fresh()->inbound_enabled_at)->toBeNull();
+});

--- a/tests/Feature/InboundProvisioningTest.php
+++ b/tests/Feature/InboundProvisioningTest.php
@@ -90,7 +90,8 @@ it('surfaces the missing worker permission with manual instructions', function (
 
     expect($domain->fresh()->inbound_enabled_at)->toBeNull()
         ->and($toast['type'])->toBe('error')
-        ->and($toast['message'])->toContain('Workers Scripts: Edit');
+        ->and($toast['message'])->toContain('Workers Scripts: Edit')
+        ->and(session('inboundError'))->toContain('Workers Scripts: Edit');
 });
 
 it('refuses to enable inbound for non-cloudflare sources', function () {


### PR DESCRIPTION
> **Stacked on #3** — contains only the inbound commits on top of the Cloudflare provider branch. Retarget/merge after #3 lands (GitHub retargets automatically if #3's branch is deleted on merge).

## Summary

Larasend can now **receive** email, not just send it. One click on a Cloudflare-source domain provisions everything; received mail lands in a new Inbound dashboard section and fires signed `inbound.received` webhooks to subscribed endpoints.

## Provider-agnostic ingestion pipeline

- `POST /api/webhooks/inbound/cloudflare/{token}` accepts envelope + base64 raw MIME (25 MiB cap), authenticated by the source's webhook token and logged to `webhook_logs`
- Raw `.eml` stored alongside outbound messages; parsed with `zbateson/mail-mime-parser` (new composer dependency, approved): subject, text, html, key headers, attachment metadata, `Message-ID`/`In-Reply-To` threading ids
- The pipeline is deliberately provider-neutral — SES receiving (S3 + SNS) and an SMTP endpoint can later feed the same ingestor, parser, and fan-out
- Ingestion failures return 5xx so the Worker throws and the sending server retries — inbound mail is never silently dropped

## One-click Cloudflare provisioning

Enabling "Receive email" on a domain:
1. uploads a **dependency-free ~20-line passthrough Worker** (`resources/cloudflare/inbound-email-worker.js`) with the signed ingestion URL as a plain-text binding,
2. enables Email Routing on the zone (tolerates already-enabled),
3. points the zone's **catch-all routing rule** at the Worker.

Mail to any address on the zone apex is received. Failures name the exact missing token permission ("Workers Scripts: Edit" / "Email Routing Rules: Edit") plus the manual alternative — the same graceful-degradation contract as sending-side domain onboarding.

## Dashboard & webhooks

- New **Inbound** sidebar section: list + preview pane (sandboxed HTML iframe or plain-text), attachment summary
- **Receive email** card on Cloudflare domains with enabled state
- `inbound.received` joins the webhook event options; deliveries are HMAC-signed and recorded in `webhook_deliveries` identically to outbound events

## Also included

- Identity input is normalized server-side: pasting `Someone@Mail.Example.COM` creates the `mail.example.com` identity (with test)

## Known v1 boundaries

- Cloudflare only (`supportsInboundReceiving` is effectively Cloudflare-scoped); SES receiving is a documented follow-up
- Receiving is zone-apex-wide via catch-all; per-address rules and subdomain routing (dashboard-only in Cloudflare's API today) are future work
- Attachment *content* stays in the stored raw MIME; only metadata is extracted

## Testing

- 192 tests passing (11 new): real multipart MIME parsing, token/provider auth on the endpoint, invalid-base64 rejection, signed fan-out to subscribed-only endpoints, full provisioning sequence against faked Cloudflare APIs, permission-degradation messaging, non-Cloudflare refusal, email→domain identity normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)