### PR TITLE
Add a team inbox with threaded conversations

### DIFF
--- a/resources/js/components/GlobalRail.vue
+++ b/resources/js/components/GlobalRail.vue
@@ -270,7 +270,7 @@ const mobileItems = computed(() => [
             <section
                 v-for="group in navigationGroups"
                 :key="group.label"
-                class="mb-2.5 pt-1.5 first:pt-0 last:mb-0"
+                class="mb-0.5 pt-1.5 first:pt-0 last:mb-0"
             >
                 <h2
                     class="mb-0.5 px-2 font-mono text-[9.5px] font-semibold tracking-[0.14em] text-zinc-400 uppercase dark:text-[#6c7177]"
@@ -282,7 +282,7 @@ const mobileItems = computed(() => [
                         v-for="item in group.items"
                         :key="item.section"
                         :href="item.href"
-                        class="relative flex min-h-8 items-center gap-2 rounded-lg px-2 text-[12.5px] font-medium transition"
+                        class="relative flex min-h-7 items-center gap-2 rounded-lg px-2 text-[12.5px] font-medium transition"
                         :class="
                             section === item.section
                                 ? 'bg-teal-50 text-zinc-950 dark:bg-teal-400/10 dark:text-zinc-100'

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -2519,12 +2519,12 @@ function recipientTitle(email: EmailRow): string | undefined {
                             </button>
                         </div>
 
-                        <div class="grid max-w-6xl gap-3">
+                        <div class="grid max-w-6xl min-w-0 gap-3">
                             <div
-                                class="grid overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-[#1d2125] dark:bg-[#101111]"
+                                class="overflow-x-auto rounded-lg border border-zinc-200 bg-white dark:border-[#1d2125] dark:bg-[#101111]"
                             >
                                 <div
-                                    class="grid grid-cols-[minmax(280px,1fr)_120px_120px_120px_130px_220px] border-b border-zinc-200 bg-zinc-50 px-3 py-2 font-mono text-[11px] tracking-widest text-zinc-500 uppercase dark:border-[#1d2125] dark:bg-[#111315]"
+                                    class="grid min-w-[970px] grid-cols-[minmax(280px,1fr)_120px_120px_120px_130px_180px] border-b border-zinc-200 bg-zinc-50 px-3 py-2 font-mono text-[11px] tracking-widest text-zinc-500 uppercase dark:border-[#1d2125] dark:bg-[#111315]"
                                 >
                                     <div>Project</div>
                                     <div>Environment</div>
@@ -2536,7 +2536,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 <div
                                     v-for="item in projects"
                                     :key="item.slug"
-                                    class="grid min-h-14 grid-cols-[minmax(280px,1fr)_120px_120px_120px_130px_220px] items-center gap-2 border-b border-zinc-200 px-3 py-2 text-sm last:border-b-0 dark:border-[#16191c]"
+                                    class="grid min-h-14 min-w-[970px] grid-cols-[minmax(280px,1fr)_120px_120px_120px_130px_180px] items-center gap-2 border-b border-zinc-200 px-3 py-2 text-sm last:border-b-0 dark:border-[#16191c]"
                                     :class="{
                                         'bg-teal-500/5 dark:bg-teal-500/10':
                                             item.is_current,
@@ -3580,7 +3580,11 @@ function recipientTitle(email: EmailRow): string | undefined {
                                     {{ inboundError }}
                                 </div>
                                 <button
-                                    v-else-if="workspace.can_manage_domains"
+                                    v-if="
+                                        workspace.can_manage_domains &&
+                                        !selectedIdentity.inbound_enabled_at &&
+                                        !inboundError
+                                    "
                                     type="button"
                                     class="rounded-lg bg-teal-400 px-3 py-2 text-sm font-bold text-zinc-950 disabled:cursor-wait disabled:opacity-60"
                                     :disabled="


### PR DESCRIPTION
## Summary

Builds a full team inbox on top of inbound receiving (#4): inbound and outbound mail are threaded into conversations with a three-pane mail UI supporting reply, compose, forward, attachments, rich text, drafts, snooze, and internal notes.

> Stacked on #4 — merge that first; this PR then retargets to `main` automatically.

## Threading foundation

- `threads` table + `ThreadResolver`: the References/In-Reply-To chain is authoritative; normalized subject (`re:`/`fwd:` stripped) plus a shared participant within 60 days is the fallback; otherwise a new thread starts.
- Inbound activity reopens a thread as unread and wakes it from archive/snooze; your own outbound sends never do.
- `php artisan larasend:thread-backfill` groups existing mail retroactively.

## Inbox UI (`/projects/{slug}/inbox`)

- Three panes: mailboxes/addresses rail, searchable thread list, conversation view with sandboxed HTML rendering.
- Mailboxes: Inbox, Unread, Snoozed, Archived, plus per-address filters; 10s polling; unread count in the tab title.
- Keyboard shortcuts: `j`/`k` navigate, `e` archive, `u` unread, `r` reply, `f` forward, `c` compose, `/` search.

## Mail actions

- **Reply** goes out as the address the thread was received on, to the last inbound sender, with In-Reply-To/References headers so external clients keep the thread intact.
- **Compose** starts new conversations from a modal; **forward** sends the latest inbound message (original attachments re-read from the stored raw MIME) with a quoted body.
- **Attachments**: uploads on reply/compose (10 files × 10 MB), inbound attachment downloads streamed on demand from the stored `.eml`.
- **Rich text** via TipTap (bold, italic, lists, quotes) submitting HTML + plain text; unsent drafts persist in localStorage per thread.
- **Snooze** presets (later today / tomorrow 9am / next Monday 9am); a new inbound message unsnoozes immediately.
- **Internal notes** render as amber timeline cards and never send email; read-only members can note even though they cannot send.

## Integration

- `inbound.received` webhook payloads now include the conversation `thread_id`.
- `php artisan db:seed --class=InboxDemoSeeder` seeds sample conversations for demos.

## Testing

- 209 tests / 1314 assertions green, including new coverage for thread resolution and backfill, mailbox filters and auto-read, reply headers/addressing, compose, forward with carried attachments, uploads landing in the stored MIME, snooze lifecycle, notes (incl. read-only members), permission gates, and cross-project 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)