### PR TITLE
Make the team inbox production ready

### DIFF
--- a/app/Http/Controllers/InboxController.php
+++ b/app/Http/Controllers/InboxController.php
@@ -30,13 +30,18 @@ class InboxController extends Controller
         $mailbox = (string) $request->string('mailbox', 'inbox');
         $address = $request->string('address')->toString() ?: null;
         $search = $request->string('q')->toString();
-        $threads = $this->threadsFor($project, $mailbox, $address, $search);
+        $assigned = $request->string('assigned')->toString();
+        $page = max(1, $request->integer('page', 1));
+        $threads = $this->threadsFor($project, $user->id, $mailbox, $address, $search, $assigned, $page);
         $selected = $this->selectedThread($project, $request->string('thread')->toString(), $threads->first()?->public_id);
 
         // Opening a conversation reads it — standard mail client behavior,
         // no separate round trip. Explicit unread stays available.
-        if ($selected && $selected->read_at === null && $request->string('thread')->toString() !== '') {
-            $selected->forceFill(['read_at' => now()])->save();
+        if ($selected && $request->string('thread')->toString() !== '') {
+            $selected->userStates()->updateOrCreate(
+                ['user_id' => $user->id],
+                ['read_at' => now(), 'last_viewed_at' => now()],
+            );
         }
 
         return Inertia::render('Inbox', [
@@ -59,21 +64,26 @@ class InboxController extends Controller
                 ];
             })->values(),
             'canSend' => $project->workspace->canSendEmail($user),
+            'teamMembers' => $project->workspace->users()->select('users.id', 'users.name', 'users.email')->orderBy('name')->get(),
+            'templates' => $project->templates()->select('id', 'name', 'subject', 'html', 'text')->orderBy('name')->get(),
             'mailbox' => $mailbox,
             'address' => $address,
-            'filters' => ['q' => $search],
+            'filters' => ['q' => $search, 'assigned' => $assigned],
             'addresses' => $this->addresses($project),
             'counts' => [
-                'inbox' => $project->threads()->whereNull('archived_at')->where($this->notSnoozed(...))->count(),
-                'unread' => $project->threads()->whereNull('archived_at')->whereNull('read_at')->where($this->notSnoozed(...))->count(),
+                'inbox' => $project->threads()->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->count(),
+                'unread' => $project->threads()->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->whereDoesntHave('userStates', fn ($query) => $query->where('user_id', $user->id)->whereNotNull('read_at'))->count(),
                 'snoozed' => $project->threads()->where('snoozed_until', '>', now())->count(),
                 'archived' => $project->threads()->whereNotNull('archived_at')->count(),
+                'closed' => $project->threads()->where('status', 'closed')->count(),
             ],
-            'threads' => $threads->map(fn (Thread $thread): array => $this->serializeThread($thread)),
+            'threads' => $threads->take(50)->map(fn (Thread $thread): array => $this->serializeThread($thread, $user->id)),
+            'pagination' => ['page' => $page, 'has_more' => $threads->count() > 50],
             'selectedThread' => $selected ? [
-                ...$this->serializeThread($selected),
+                ...$this->serializeThread($selected, $user->id),
                 'messages' => $this->messagesFor($selected),
                 'reply_from' => $this->replyFromFor($selected, $source?->default_from_email),
+                'active_viewers' => $selected->userStates()->with('user:id,name')->where('user_id', '!=', $user->id)->where('last_viewed_at', '>=', now()->subMinutes(2))->get()->map(fn ($state): array => ['id' => $state->user_id, 'name' => $state->user?->name ?? 'Teammate'])->values(),
             ] : null,
         ]);
     }
@@ -81,23 +91,30 @@ class InboxController extends Controller
     /**
      * @return Collection<int, Thread>
      */
-    private function threadsFor(Project $project, string $mailbox, ?string $address, string $search)
+    private function threadsFor(Project $project, int $userId, string $mailbox, ?string $address, string $search, string $assigned, int $page)
     {
         return $project->threads()
-            ->when($mailbox === 'inbox', fn ($query) => $query->whereNull('archived_at')->where($this->notSnoozed(...)))
-            ->when($mailbox === 'unread', fn ($query) => $query->whereNull('archived_at')->whereNull('read_at')->where($this->notSnoozed(...)))
+            ->when($mailbox === 'inbox', fn ($query) => $query->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...)))
+            ->when($mailbox === 'unread', fn ($query) => $query->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->whereDoesntHave('userStates', fn ($state) => $state->where('user_id', $userId)->whereNotNull('read_at')))
             ->when($mailbox === 'snoozed', fn ($query) => $query->where('snoozed_until', '>', now()))
             ->when($mailbox === 'archived', fn ($query) => $query->whereNotNull('archived_at'))
+            ->when($mailbox === 'closed', fn ($query) => $query->where('status', 'closed'))
             ->when($address, fn ($query) => $query->whereJsonContains('participants', Str::lower($address)))
+            ->when($assigned === 'mine', fn ($query) => $query->where('assigned_to_user_id', $userId))
+            ->when($assigned === 'unassigned', fn ($query) => $query->whereNull('assigned_to_user_id'))
             ->when($search !== '', function ($query) use ($search): void {
                 $query->where(function ($inner) use ($search): void {
                     $inner->whereLike('subject', "%{$search}%")
                         ->orWhereLike('last_snippet', "%{$search}%")
-                        ->orWhereLike('participants', "%{$search}%");
+                        ->orWhereLike('participants', "%{$search}%")
+                        ->orWhereHas('inboundEmails', fn ($messages) => $messages->whereLike('text', "%{$search}%"))
+                        ->orWhereHas('emails', fn ($messages) => $messages->whereLike('text', "%{$search}%"));
                 });
             })
             ->orderByDesc('last_activity_at')
-            ->limit(50)
+            ->with(['assignedTo:id,name', 'userStates' => fn ($query) => $query->where('user_id', $userId)])
+            ->offset(($page - 1) * 50)
+            ->limit(51)
             ->get();
     }
 
@@ -120,8 +137,10 @@ class InboxController extends Controller
     /**
      * @return array<string, mixed>
      */
-    private function serializeThread(Thread $thread): array
+    private function serializeThread(Thread $thread, int $userId): array
     {
+        $state = $thread->userStates->firstWhere('user_id', $userId);
+
         return [
             'public_id' => $thread->public_id,
             'subject' => $thread->subject,
@@ -129,7 +148,7 @@ class InboxController extends Controller
             'snippet' => $thread->last_snippet,
             'direction' => $thread->last_direction,
             'message_count' => $thread->message_count,
-            'unread' => $thread->read_at === null,
+            'unread' => $state?->read_at === null,
             'archived' => $thread->archived_at !== null,
             'snoozed' => $thread->snoozed_until?->isFuture() === true,
             'snoozed_until_human' => $thread->snoozed_until?->isFuture() === true
@@ -137,6 +156,10 @@ class InboxController extends Controller
                 : null,
             'last_activity_at' => $thread->last_activity_at?->toIso8601String(),
             'last_activity_human' => $thread->last_activity_at?->diffForHumans(short: true),
+            'status' => $thread->status,
+            'priority' => $thread->priority,
+            'tags' => $thread->tags ?? [],
+            'assigned_to' => $thread->assignedTo ? ['id' => $thread->assignedTo->id, 'name' => $thread->assignedTo->name] : null,
         ];
     }
 
@@ -163,7 +186,7 @@ class InboxController extends Controller
             'at_human' => $message->received_at?->diffForHumans(short: true),
         ]);
 
-        $outbound = $thread->emails()->with('recipients')->get()->map(fn (Email $message): array => [
+        $outbound = $thread->emails()->with(['recipients', 'attachments', 'events' => fn ($query) => $query->latest('occurred_at')->limit(1)])->get()->map(fn (Email $message): array => [
             'id' => $message->public_id,
             'direction' => 'outbound',
             'from' => trim(($message->from_name ? $message->from_name.' ' : '').'<'.$message->from_email.'>'),
@@ -172,8 +195,10 @@ class InboxController extends Controller
             'subject' => $message->subject,
             'text' => $message->text,
             'html' => $message->html,
-            'attachments' => [],
+            'attachments' => $message->attachments->map(fn ($attachment): array => ['filename' => $attachment->filename, 'content_type' => $attachment->content_type, 'size' => $attachment->size])->all(),
             'status' => $message->status,
+            'status_detail' => $message->events->first()?->payload['diagnosticCode'] ?? $message->events->first()?->payload['diagnostic'] ?? null,
+            'can_retry' => in_array($message->status, ['failed', 'bounced'], true),
             'at' => $message->created_at?->toIso8601String(),
             'at_human' => $message->created_at?->diffForHumans(short: true),
         ]);

--- a/app/Http/Controllers/InboxController.php
+++ b/app/Http/Controllers/InboxController.php
@@ -9,6 +9,7 @@ use App\Models\Thread;
 use App\Models\ThreadNote;
 use App\Models\User;
 use App\Support\ProjectContext;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -69,7 +70,7 @@ class InboxController extends Controller
             'mailbox' => $mailbox,
             'address' => $address,
             'filters' => ['q' => $search, 'assigned' => $assigned],
-            'addresses' => $this->addresses($project),
+            'addresses' => $this->addresses($project, $user->id, $mailbox),
             'counts' => [
                 'inbox' => $project->threads()->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->count(),
                 'unread' => $project->threads()->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->whereDoesntHave('userStates', fn ($query) => $query->where('user_id', $user->id)->whereNotNull('read_at'))->count(),
@@ -101,12 +102,11 @@ class InboxController extends Controller
     private function threadsFor(Project $project, int $userId, string $mailbox, ?string $address, string $search, string $assigned, int $page)
     {
         return $project->threads()
-            ->when($mailbox === 'inbox', fn ($query) => $query->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...)))
-            ->when($mailbox === 'unread', fn ($query) => $query->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->whereDoesntHave('userStates', fn ($state) => $state->where('user_id', $userId)->whereNotNull('read_at')))
-            ->when($mailbox === 'snoozed', fn ($query) => $query->where('snoozed_until', '>', now()))
-            ->when($mailbox === 'archived', fn ($query) => $query->whereNotNull('archived_at'))
-            ->when($mailbox === 'closed', fn ($query) => $query->where('status', 'closed'))
-            ->when($address, fn ($query) => $query->whereJsonContains('participants', Str::lower($address)))
+            ->tap(fn (Builder $query) => $this->applyMailbox($query, $mailbox, $userId))
+            ->when($address, fn ($query) => $query->whereHas(
+                'inboundEmails',
+                fn ($messages) => $messages->whereRaw('LOWER(to_email) = ?', [Str::lower($address)]),
+            ))
             ->when($assigned === 'mine', fn ($query) => $query->where('assigned_to_user_id', $userId))
             ->when($assigned === 'unassigned', fn ($query) => $query->whereNull('assigned_to_user_id'))
             ->when($search !== '', function ($query) use ($search): void {
@@ -123,6 +123,16 @@ class InboxController extends Controller
             ->offset(($page - 1) * 50)
             ->limit(51)
             ->get();
+    }
+
+    private function applyMailbox(Builder $query, string $mailbox, int $userId): void
+    {
+        $query
+            ->when($mailbox === 'inbox', fn ($threads) => $threads->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...)))
+            ->when($mailbox === 'unread', fn ($threads) => $threads->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->whereDoesntHave('userStates', fn ($state) => $state->where('user_id', $userId)->whereNotNull('read_at')))
+            ->when($mailbox === 'snoozed', fn ($threads) => $threads->where('snoozed_until', '>', now()))
+            ->when($mailbox === 'archived', fn ($threads) => $threads->whereNotNull('archived_at'))
+            ->when($mailbox === 'closed', fn ($threads) => $threads->where('status', 'closed'));
     }
 
     private function notSnoozed(mixed $query): void
@@ -246,15 +256,17 @@ class InboxController extends Controller
      *
      * @return array<int, array{address: string, count: int}>
      */
-    private function addresses(Project $project): array
+    private function addresses(Project $project, int $userId, string $mailbox): array
     {
         return $project->inboundEmails()
-            ->selectRaw('to_email, count(*) as total')
-            ->groupBy('to_email')
+            ->whereNotNull('thread_id')
+            ->whereHas('thread', fn (Builder $query) => $this->applyMailbox($query, $mailbox, $userId))
+            ->selectRaw('LOWER(to_email) as address, count(distinct thread_id) as total')
+            ->groupByRaw('LOWER(to_email)')
             ->orderByDesc('total')
             ->limit(12)
             ->get()
-            ->map(fn ($row): array => ['address' => $row->to_email, 'count' => (int) $row->total])
+            ->map(fn ($row): array => ['address' => $row->address, 'count' => (int) $row->total])
             ->all();
     }
 }

--- a/app/Http/Controllers/InboxController.php
+++ b/app/Http/Controllers/InboxController.php
@@ -84,6 +84,13 @@ class InboxController extends Controller
                 'messages' => $this->messagesFor($selected),
                 'reply_from' => $this->replyFromFor($selected, $source?->default_from_email),
                 'active_viewers' => $selected->userStates()->with('user:id,name')->where('user_id', '!=', $user->id)->where('last_viewed_at', '>=', now()->subMinutes(2))->get()->map(fn ($state): array => ['id' => $state->user_id, 'name' => $state->user?->name ?? 'Teammate'])->values(),
+                'activity' => $selected->events()->with('user:id,name')->latest()->limit(20)->get()->map(fn ($event): array => [
+                    'id' => $event->id,
+                    'type' => $event->type,
+                    'actor' => $event->user?->name ?? 'System',
+                    'metadata' => $event->metadata ?? [],
+                    'at_human' => $event->created_at?->diffForHumans(short: true),
+                ]),
             ] : null,
         ]);
     }

--- a/app/Http/Controllers/InboxController.php
+++ b/app/Http/Controllers/InboxController.php
@@ -70,7 +70,7 @@ class InboxController extends Controller
             'mailbox' => $mailbox,
             'address' => $address,
             'filters' => ['q' => $search, 'assigned' => $assigned],
-            'addresses' => $this->addresses($project, $user->id, $mailbox),
+            'addresses' => $this->addresses($project),
             'counts' => [
                 'inbox' => $project->threads()->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->count(),
                 'unread' => $project->threads()->whereNull('archived_at')->where('status', '!=', 'closed')->where($this->notSnoozed(...))->whereDoesntHave('userStates', fn ($query) => $query->where('user_id', $user->id)->whereNotNull('read_at'))->count(),
@@ -256,11 +256,10 @@ class InboxController extends Controller
      *
      * @return array<int, array{address: string, count: int}>
      */
-    private function addresses(Project $project, int $userId, string $mailbox): array
+    private function addresses(Project $project): array
     {
         return $project->inboundEmails()
             ->whereNotNull('thread_id')
-            ->whereHas('thread', fn (Builder $query) => $this->applyMailbox($query, $mailbox, $userId))
             ->selectRaw('LOWER(to_email) as address, count(distinct thread_id) as total')
             ->groupByRaw('LOWER(to_email)')
             ->orderByDesc('total')

--- a/app/Http/Controllers/ThreadActionController.php
+++ b/app/Http/Controllers/ThreadActionController.php
@@ -106,6 +106,8 @@ class ThreadActionController extends Controller
         $validated = $request->validate([
             'from' => ['nullable', 'email:rfc'],
             'to' => ['required', 'email:rfc'],
+            'cc' => ['nullable', 'string', 'max:2000'],
+            'bcc' => ['nullable', 'string', 'max:2000'],
             'subject' => ['required', 'string', 'max:255'],
             'text' => ['required', 'string', 'max:100000'],
             'html' => ['nullable', 'string', 'max:400000'],
@@ -119,6 +121,8 @@ class ThreadActionController extends Controller
             $email = $this->sendService->send($project, $source, [
                 'from' => ($validated['from'] ?? null) ?: $source->default_from_email,
                 'to' => [$validated['to']],
+                'cc' => $this->recipientList($validated['cc'] ?? ''),
+                'bcc' => $this->recipientList($validated['bcc'] ?? ''),
                 'subject' => $validated['subject'],
                 'text' => $validated['text'],
                 'html' => ($validated['html'] ?? null) ?: $this->textToHtml($validated['text']),
@@ -257,11 +261,22 @@ class ThreadActionController extends Controller
             ->implode("\n");
     }
 
+    /** @return array<int, string> */
+    private function recipientList(string $value): array
+    {
+        $recipients = collect(explode(',', $value))->map(fn (string $email): string => trim($email))->filter()->values();
+
+        if ($recipients->contains(fn (string $email): bool => filter_var($email, FILTER_VALIDATE_EMAIL) === false)) {
+            throw ValidationException::withMessages(['cc' => 'CC and BCC must contain valid comma-separated email addresses.']);
+        }
+
+        return $recipients->all();
+    }
+
     public function read(Request $request, string $projectSlug, Thread $thread): RedirectResponse
     {
         $this->authorizeThread($thread);
-
-        $thread->forceFill(['read_at' => now()])->save();
+        $thread->userStates()->updateOrCreate(['user_id' => Auth::id()], ['read_at' => now(), 'last_viewed_at' => now()]);
 
         return back();
     }
@@ -270,7 +285,7 @@ class ThreadActionController extends Controller
     {
         $this->authorizeThread($thread);
 
-        $thread->forceFill(['read_at' => null])->save();
+        $thread->userStates()->updateOrCreate(['user_id' => Auth::id()], ['read_at' => null]);
 
         return back();
     }
@@ -280,6 +295,7 @@ class ThreadActionController extends Controller
         $this->authorizeThread($thread);
 
         $thread->forceFill(['archived_at' => now()])->save();
+        $this->recordEvent($thread, 'archived');
 
         return back();
     }
@@ -289,6 +305,7 @@ class ThreadActionController extends Controller
         $this->authorizeThread($thread);
 
         $thread->forceFill(['archived_at' => null])->save();
+        $this->recordEvent($thread, 'restored');
 
         return back();
     }
@@ -312,6 +329,7 @@ class ThreadActionController extends Controller
         };
 
         $thread->forceFill(['snoozed_until' => $until, 'read_at' => $thread->read_at ?? now()])->save();
+        $this->recordEvent($thread, 'snoozed', ['until' => $until->toIso8601String()]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => 'Snoozed until '.$until->format('D, M j g:ia').'.']);
 
@@ -323,6 +341,29 @@ class ThreadActionController extends Controller
         $this->authorizeThread($thread);
 
         $thread->forceFill(['snoozed_until' => null])->save();
+        $this->recordEvent($thread, 'unsnoozed');
+
+        return back();
+    }
+
+    public function updateWorkflow(Request $request, string $projectSlug, Thread $thread): RedirectResponse
+    {
+        $project = $this->authorizeThread($thread);
+        $validated = $request->validate([
+            'status' => ['sometimes', 'in:open,pending,closed'],
+            'priority' => ['sometimes', 'in:low,normal,high,urgent'],
+            'assigned_to_user_id' => ['nullable', 'integer'],
+            'tags' => ['sometimes', 'array', 'max:10'],
+            'tags.*' => ['string', 'max:32'],
+        ]);
+
+        if (array_key_exists('assigned_to_user_id', $validated) && $validated['assigned_to_user_id'] !== null) {
+            abort_unless($project->workspace->users()->whereKey($validated['assigned_to_user_id'])->exists(), 422);
+        }
+
+        $before = $thread->only(['status', 'priority', 'assigned_to_user_id', 'tags']);
+        $thread->forceFill($validated)->save();
+        $this->recordEvent($thread, 'workflow_updated', ['before' => $before, 'after' => $thread->only(array_keys($validated))]);
 
         return back();
     }
@@ -360,5 +401,11 @@ class ThreadActionController extends Controller
         abort_unless($thread->project_id === $project->id, 404);
 
         return $project;
+    }
+
+    /** @param array<string, mixed> $metadata */
+    private function recordEvent(Thread $thread, string $type, array $metadata = []): void
+    {
+        $thread->events()->create(['user_id' => Auth::id(), 'type' => $type, 'metadata' => $metadata]);
     }
 }

--- a/app/Http/Controllers/ThreadActionController.php
+++ b/app/Http/Controllers/ThreadActionController.php
@@ -40,6 +40,9 @@ class ThreadActionController extends Controller
         $validated = $request->validate([
             'text' => ['required', 'string', 'max:100000'],
             'html' => ['nullable', 'string', 'max:400000'],
+            'reply_all' => ['nullable', 'boolean'],
+            'cc' => ['nullable', 'string', 'max:2000'],
+            'bcc' => ['nullable', 'string', 'max:2000'],
             'attachments' => ['nullable', 'array', 'max:10'],
             'attachments.*' => ['file', 'max:10240'],
         ]);
@@ -62,11 +65,19 @@ class ThreadActionController extends Controller
         $subject = Str::startsWith(Str::lower((string) $thread->subject), 're:')
             ? (string) $thread->subject
             : 'Re: '.$thread->subject;
+        $source = $this->projectContext->currentSource($project);
 
         try {
-            $this->sendService->send($project, $this->projectContext->currentSource($project), [
+            $this->sendService->send($project, $source, [
                 'from' => $lastInbound->to_email,
                 'to' => [$lastInbound->from_email],
+                'cc' => collect($this->recipientList($validated['cc'] ?? ''))
+                    ->merge(($validated['reply_all'] ?? false) ? $this->replyAllRecipients($lastInbound) : [])
+                    ->reject(fn (string $email): bool => collect([$lastInbound->from_email, $lastInbound->to_email, $source?->default_from_email])->filter()->contains(fn (string $own): bool => strcasecmp(trim($email), trim($own)) === 0))
+                    ->unique(fn (string $email): string => Str::lower($email))
+                    ->values()
+                    ->all(),
+                'bcc' => $this->recipientList($validated['bcc'] ?? ''),
                 'subject' => $subject,
                 'text' => $validated['text'],
                 'html' => ($validated['html'] ?? null) ?: $this->textToHtml($validated['text']),
@@ -105,7 +116,7 @@ class ThreadActionController extends Controller
 
         $validated = $request->validate([
             'from' => ['nullable', 'email:rfc'],
-            'to' => ['required', 'email:rfc'],
+            'to' => ['required', 'string', 'max:2000'],
             'cc' => ['nullable', 'string', 'max:2000'],
             'bcc' => ['nullable', 'string', 'max:2000'],
             'subject' => ['required', 'string', 'max:255'],
@@ -120,7 +131,7 @@ class ThreadActionController extends Controller
         try {
             $email = $this->sendService->send($project, $source, [
                 'from' => ($validated['from'] ?? null) ?: $source->default_from_email,
-                'to' => [$validated['to']],
+                'to' => $this->recipientList($validated['to']),
                 'cc' => $this->recipientList($validated['cc'] ?? ''),
                 'bcc' => $this->recipientList($validated['bcc'] ?? ''),
                 'subject' => $validated['subject'],
@@ -271,6 +282,47 @@ class ThreadActionController extends Controller
         }
 
         return $recipients->all();
+    }
+
+    /** @return array<int, string> */
+    private function replyAllRecipients(InboundEmail $inbound): array
+    {
+        return $this->recipientList(collect([
+            $inbound->headers['To'] ?? $inbound->headers['to'] ?? '',
+            $inbound->headers['Cc'] ?? $inbound->headers['cc'] ?? '',
+        ])->filter()->implode(','));
+    }
+
+    public function bulk(Request $request, string $projectSlug): RedirectResponse
+    {
+        $user = Auth::user();
+        abort_unless($user instanceof User, 403);
+        $project = $this->projectContext->projectFor($user, $projectSlug);
+        $validated = $request->validate([
+            'thread_ids' => ['required', 'array', 'min:1', 'max:50'],
+            'thread_ids.*' => ['string'],
+            'action' => ['required', 'in:archive,open,pending,close,assign,mark_read,mark_unread'],
+            'assigned_to_user_id' => ['nullable', 'integer'],
+        ]);
+
+        if ($validated['action'] === 'assign' && ($validated['assigned_to_user_id'] ?? null) !== null) {
+            abort_unless($project->workspace->users()->whereKey($validated['assigned_to_user_id'])->exists(), 422);
+        }
+
+        $threads = $project->threads()->whereIn('public_id', $validated['thread_ids'])->get();
+        abort_unless($threads->count() === count(array_unique($validated['thread_ids'])), 404);
+
+        foreach ($threads as $thread) {
+            match ($validated['action']) {
+                'archive' => $thread->forceFill(['archived_at' => now()])->save(),
+                'open', 'pending', 'close' => $thread->forceFill(['status' => $validated['action'] === 'close' ? 'closed' : $validated['action']])->save(),
+                'assign' => $thread->forceFill(['assigned_to_user_id' => $validated['assigned_to_user_id'] ?? null])->save(),
+                'mark_read', 'mark_unread' => $thread->userStates()->updateOrCreate(['user_id' => $user->id], ['read_at' => $validated['action'] === 'mark_read' ? now() : null]),
+            };
+            $this->recordEvent($thread, 'bulk_'.$validated['action']);
+        }
+
+        return back();
     }
 
     public function read(Request $request, string $projectSlug, Thread $thread): RedirectResponse

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -22,7 +22,13 @@ class Thread extends Model
         'read_at',
         'archived_at',
         'snoozed_until',
+        'status',
+        'priority',
+        'assigned_to_user_id',
+        'tags',
     ];
+
+    protected $attributes = ['status' => 'open', 'priority' => 'normal'];
 
     protected function casts(): array
     {
@@ -32,6 +38,7 @@ class Thread extends Model
             'read_at' => 'datetime',
             'archived_at' => 'datetime',
             'snoozed_until' => 'datetime',
+            'tags' => 'array',
         ];
     }
 
@@ -58,6 +65,21 @@ class Thread extends Model
     public function notes(): HasMany
     {
         return $this->hasMany(ThreadNote::class);
+    }
+
+    public function assignedTo(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_to_user_id');
+    }
+
+    public function userStates(): HasMany
+    {
+        return $this->hasMany(ThreadUserState::class);
+    }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(ThreadEvent::class);
     }
 
     /**

--- a/app/Models/ThreadEvent.php
+++ b/app/Models/ThreadEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ThreadEvent extends Model
+{
+    protected $fillable = ['thread_id', 'user_id', 'type', 'metadata'];
+
+    protected function casts(): array
+    {
+        return ['metadata' => 'array'];
+    }
+
+    public function thread(): BelongsTo
+    {
+        return $this->belongsTo(Thread::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ThreadUserState.php
+++ b/app/Models/ThreadUserState.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ThreadUserState extends Model
+{
+    protected $fillable = ['thread_id', 'user_id', 'read_at', 'last_viewed_at'];
+
+    protected function casts(): array
+    {
+        return ['read_at' => 'datetime', 'last_viewed_at' => 'datetime'];
+    }
+
+    public function thread(): BelongsTo
+    {
+        return $this->belongsTo(Thread::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/ThreadResolver.php
+++ b/app/Services/ThreadResolver.php
@@ -189,6 +189,11 @@ class ThreadResolver
             'read_at' => $direction === 'inbound' ? null : ($thread->read_at ?? now()),
             'archived_at' => $direction === 'inbound' ? null : $thread->archived_at,
             'snoozed_until' => $direction === 'inbound' ? null : $thread->snoozed_until,
+            'status' => $direction === 'inbound' ? 'open' : $thread->status,
         ])->save();
+
+        if ($direction === 'inbound') {
+            $thread->userStates()->update(['read_at' => null]);
+        }
     }
 }

--- a/database/migrations/2026_07_12_034640_add_team_workflow_to_threads_table.php
+++ b/database/migrations/2026_07_12_034640_add_team_workflow_to_threads_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('threads', function (Blueprint $table) {
+            $table->string('status')->default('open')->after('snoozed_until')->index();
+            $table->string('priority')->default('normal')->after('status')->index();
+            $table->foreignId('assigned_to_user_id')->nullable()->after('priority')->constrained('users')->nullOnDelete();
+            $table->json('tags')->nullable()->after('assigned_to_user_id');
+            $table->index(['project_id', 'status', 'assigned_to_user_id', 'last_activity_at'], 'threads_team_queue_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('threads', function (Blueprint $table) {
+            $table->dropIndex('threads_team_queue_index');
+            $table->dropConstrainedForeignId('assigned_to_user_id');
+            $table->dropColumn(['status', 'priority', 'tags']);
+        });
+    }
+};

--- a/database/migrations/2026_07_12_034640_create_thread_events_table.php
+++ b/database/migrations/2026_07_12_034640_create_thread_events_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('thread_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('thread_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('type')->index();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->index(['thread_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('thread_events');
+    }
+};

--- a/database/migrations/2026_07_12_034640_create_thread_user_states_table.php
+++ b/database/migrations/2026_07_12_034640_create_thread_user_states_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('thread_user_states', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('thread_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('read_at')->nullable();
+            $table->timestamp('last_viewed_at')->nullable();
+            $table->timestamps();
+            $table->unique(['thread_id', 'user_id']);
+            $table->index(['user_id', 'read_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('thread_user_states');
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -77,6 +77,24 @@
     ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
     }
+
+    select {
+        color-scheme: light;
+    }
+
+    select option {
+        background-color: #ffffff;
+        color: #3f3f46;
+    }
+
+    .dark select {
+        color-scheme: dark;
+    }
+
+    .dark select option {
+        background-color: #16191c;
+        color: #e4e4e7;
+    }
 }
 
 @layer utilities {

--- a/resources/js/components/GlobalRail.vue
+++ b/resources/js/components/GlobalRail.vue
@@ -267,7 +267,7 @@ const mobileItems = computed(() => [
         </div>
 
         <nav
-            class="grid min-h-0 flex-1 content-start gap-3 overflow-y-auto px-3 py-3"
+            class="grid min-h-0 flex-1 content-start gap-5 overflow-y-auto px-3 py-3"
         >
             <section v-for="group in navigationGroups" :key="group.label">
                 <h2

--- a/resources/js/components/GlobalRail.vue
+++ b/resources/js/components/GlobalRail.vue
@@ -266,12 +266,10 @@ const mobileItems = computed(() => [
             </div>
         </div>
 
-        <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-2">
-            <section
-                v-for="group in navigationGroups"
-                :key="group.label"
-                class="mb-0.5 pt-1.5 first:pt-0 last:mb-0"
-            >
+        <nav
+            class="grid min-h-0 flex-1 content-start gap-3 overflow-y-auto px-3 py-3"
+        >
+            <section v-for="group in navigationGroups" :key="group.label">
                 <h2
                     class="mb-0.5 px-2 font-mono text-[9.5px] font-semibold tracking-[0.14em] text-zinc-400 uppercase dark:text-[#6c7177]"
                 >

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -6,6 +6,8 @@ import {
     ArchiveRestore,
     ArrowLeft,
     AtSign,
+    Bell,
+    CheckSquare,
     Forward,
     Inbox as InboxIcon,
     Mail,
@@ -18,6 +20,8 @@ import {
     Send,
     SlidersHorizontal,
     StickyNote,
+    Tag,
+    History,
     X,
 } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
@@ -107,6 +111,13 @@ const props = defineProps<{
               messages: Message[];
               reply_from: string | null;
               active_viewers: { id: number; name: string }[];
+              activity: {
+                  id: number;
+                  type: string;
+                  actor: string;
+                  metadata: Record<string, unknown>;
+                  at_human: string | null;
+              }[];
           })
         | null;
 }>();
@@ -115,6 +126,11 @@ const searchQuery = ref(props.filters.q);
 const searchInput = ref<HTMLInputElement | null>(null);
 const mobileThreadOpen = ref(false);
 const showFilters = ref(false);
+const bulkMode = ref(false);
+const selectedThreadIds = ref<string[]>([]);
+const showActivity = ref(false);
+const tagInput = ref('');
+const notificationsEnabled = ref(false);
 let searchTimer: ReturnType<typeof window.setTimeout> | null = null;
 
 const inboxPath = computed(() => `${props.project.path}/inbox`);
@@ -219,7 +235,9 @@ function threadAction(action: string): void {
     );
 }
 
-function updateWorkflow(data: Record<string, string | number | null>): void {
+function updateWorkflow(
+    data: Record<string, string | number | string[] | null>,
+): void {
     if (!props.selectedThread) {
         return;
     }
@@ -228,6 +246,79 @@ function updateWorkflow(data: Record<string, string | number | null>): void {
         `${props.project.path}/threads/${props.selectedThread.public_id}/workflow`,
         data,
         { preserveScroll: true, showProgress: false },
+    );
+}
+
+function toggleThreadSelection(publicId: string): void {
+    selectedThreadIds.value = selectedThreadIds.value.includes(publicId)
+        ? selectedThreadIds.value.filter((id) => id !== publicId)
+        : [...selectedThreadIds.value, publicId];
+}
+
+function bulkAction(
+    action: string,
+    assignedToUserId: number | null = null,
+): void {
+    if (!selectedThreadIds.value.length) {
+        return;
+    }
+
+    router.post(
+        `${props.project.path}/inbox/bulk`,
+        {
+            thread_ids: selectedThreadIds.value,
+            action,
+            assigned_to_user_id: assignedToUserId,
+        },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                selectedThreadIds.value = [];
+                bulkMode.value = false;
+            },
+        },
+    );
+}
+
+function addTag(): void {
+    const tag = tagInput.value.trim().toLowerCase();
+
+    if (
+        !props.selectedThread ||
+        !tag ||
+        props.selectedThread.tags.includes(tag)
+    ) {
+        return;
+    }
+
+    updateWorkflow({ tags: [...props.selectedThread.tags, tag] });
+    tagInput.value = '';
+}
+
+function removeTag(tag: string): void {
+    if (!props.selectedThread) {
+        return;
+    }
+
+    updateWorkflow({
+        tags: props.selectedThread.tags.filter((item) => item !== tag),
+    });
+}
+
+async function toggleNotifications(): Promise<void> {
+    if (!('Notification' in window)) {
+        return;
+    }
+
+    const permission =
+        Notification.permission === 'granted'
+            ? 'granted'
+            : await Notification.requestPermission();
+    notificationsEnabled.value =
+        permission === 'granted' ? !notificationsEnabled.value : false;
+    localStorage.setItem(
+        'larasend:inbox-notifications',
+        notificationsEnabled.value ? '1' : '0',
     );
 }
 
@@ -341,6 +432,8 @@ onMounted(() => {
         'thread',
     );
     window.addEventListener('keydown', onKeydown);
+    notificationsEnabled.value =
+        localStorage.getItem('larasend:inbox-notifications') === '1';
 });
 onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
 
@@ -350,7 +443,32 @@ usePoll(
     { autoStart: true },
 );
 
-const replyForm = useForm({ text: '', html: '', attachments: [] as File[] });
+let previousUnreadCount = props.counts.unread;
+watch(
+    () => props.counts.unread,
+    (count) => {
+        if (
+            notificationsEnabled.value &&
+            count > previousUnreadCount &&
+            Notification.permission === 'granted'
+        ) {
+            new Notification('New Larasend conversation', {
+                body: `${count} unread conversations in ${props.project.name}`,
+            });
+        }
+
+        previousUnreadCount = count;
+    },
+);
+
+const replyForm = useForm({
+    text: '',
+    html: '',
+    reply_all: false,
+    cc: '',
+    bcc: '',
+    attachments: [] as File[],
+});
 const replyEditor = ref<InstanceType<typeof RichTextEditor> | null>(null);
 
 function sendReply(): void {
@@ -702,6 +820,19 @@ function participantSummary(thread: ThreadRow): string {
             </button>
             <button
                 type="button"
+                class="grid size-8 place-items-center rounded-md border border-zinc-200 text-zinc-500 dark:border-[#1d2125]"
+                :class="notificationsEnabled ? 'text-teal-500' : ''"
+                :title="
+                    notificationsEnabled
+                        ? 'Disable new-mail notifications'
+                        : 'Enable new-mail notifications'
+                "
+                @click="toggleNotifications"
+            >
+                <Bell class="size-3.5" />
+            </button>
+            <button
+                type="button"
                 title="Keyboard shortcuts (?)"
                 class="grid size-8 place-items-center rounded-md border border-zinc-200 font-mono text-xs font-semibold text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-950 dark:border-[#1d2125] dark:text-zinc-400 dark:hover:bg-[#16191c] dark:hover:text-zinc-100"
                 :class="canSend ? '' : 'ml-auto'"
@@ -806,19 +937,94 @@ function participantSummary(thread: ThreadRow): string {
                 "
             >
                 <div
-                    class="border-b border-zinc-200 p-2.5 dark:border-[#1d2125]"
+                    class="grid gap-2 border-b border-zinc-200 p-2.5 dark:border-[#1d2125]"
                 >
-                    <div class="relative">
-                        <Search
-                            class="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-400"
-                        />
-                        <input
-                            ref="searchInput"
-                            v-model="searchQuery"
-                            placeholder="Search conversations"
-                            class="h-8 w-full rounded-md border border-zinc-200 bg-white pl-8 text-[12.5px] transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#1d2125] dark:bg-[#101111]"
-                            @input="onSearchInput"
-                        />
+                    <div class="flex gap-2">
+                        <div class="relative min-w-0 flex-1">
+                            <Search
+                                class="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-400"
+                            />
+                            <input
+                                ref="searchInput"
+                                v-model="searchQuery"
+                                placeholder="Search conversations"
+                                class="h-8 w-full rounded-md border border-zinc-200 bg-white pl-8 text-[12.5px] transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#1d2125] dark:bg-[#101111]"
+                                @input="onSearchInput"
+                            />
+                        </div>
+                        <button
+                            type="button"
+                            class="grid size-8 place-items-center rounded-md border border-zinc-200 text-zinc-500 dark:border-[#1d2125]"
+                            :class="
+                                bulkMode
+                                    ? 'bg-teal-50 text-teal-700 dark:bg-teal-400/10 dark:text-teal-300'
+                                    : ''
+                            "
+                            title="Select conversations"
+                            @click="
+                                bulkMode = !bulkMode;
+                                selectedThreadIds = [];
+                            "
+                        >
+                            <CheckSquare class="size-3.5" />
+                        </button>
+                    </div>
+                    <div
+                        v-if="bulkMode"
+                        class="flex flex-wrap items-center gap-1.5 text-xs"
+                    >
+                        <span class="mr-auto font-semibold"
+                            >{{ selectedThreadIds.length }} selected</span
+                        >
+                        <button
+                            type="button"
+                            class="rounded border border-zinc-200 px-2 py-1 dark:border-[#1d2125]"
+                            :disabled="!selectedThreadIds.length"
+                            @click="bulkAction('mark_read')"
+                        >
+                            Read
+                        </button>
+                        <button
+                            type="button"
+                            class="rounded border border-zinc-200 px-2 py-1 dark:border-[#1d2125]"
+                            :disabled="!selectedThreadIds.length"
+                            @click="bulkAction('archive')"
+                        >
+                            Archive
+                        </button>
+                        <button
+                            type="button"
+                            class="rounded border border-zinc-200 px-2 py-1 dark:border-[#1d2125]"
+                            :disabled="!selectedThreadIds.length"
+                            @click="bulkAction('close')"
+                        >
+                            Close
+                        </button>
+                        <select
+                            class="h-7 rounded border border-zinc-200 bg-transparent px-1 dark:border-[#1d2125]"
+                            :disabled="!selectedThreadIds.length"
+                            @change="
+                                bulkAction(
+                                    'assign',
+                                    ($event.target as HTMLSelectElement).value
+                                        ? Number(
+                                              (
+                                                  $event.target as HTMLSelectElement
+                                              ).value,
+                                          )
+                                        : null,
+                                )
+                            "
+                        >
+                            <option value="">Assign…</option>
+                            <option
+                                v-for="member in teamMembers"
+                                :key="member.id"
+                                :value="member.id"
+                            >
+                                {{ member.name }}
+                            </option>
+                        </select>
                     </div>
                 </div>
                 <div class="min-h-0 overflow-auto">
@@ -841,9 +1047,28 @@ function participantSummary(thread: ThreadRow): string {
                                 ? 'bg-teal-50/70 dark:bg-teal-400/10'
                                 : ''
                         "
-                        @click="openThread(thread.public_id)"
+                        @click="
+                            bulkMode
+                                ? toggleThreadSelection(thread.public_id)
+                                : openThread(thread.public_id)
+                        "
                     >
                         <div class="flex items-baseline gap-2">
+                            <span
+                                v-if="bulkMode"
+                                class="grid size-4 shrink-0 place-items-center rounded border border-zinc-300 text-[10px]"
+                                :class="
+                                    selectedThreadIds.includes(thread.public_id)
+                                        ? 'border-teal-400 bg-teal-400 text-zinc-950'
+                                        : ''
+                                "
+                            >
+                                {{
+                                    selectedThreadIds.includes(thread.public_id)
+                                        ? '✓'
+                                        : ''
+                                }}
+                            </span>
                             <span
                                 v-if="thread.unread"
                                 class="size-1.5 shrink-0 self-center rounded-full bg-teal-400"
@@ -955,6 +1180,21 @@ function participantSummary(thread: ThreadRow): string {
                         <p class="truncate font-mono text-[11px] text-zinc-500">
                             {{ selectedThread.participants.join(' · ') }}
                         </p>
+                        <div
+                            v-if="selectedThread.tags.length"
+                            class="mt-1 flex flex-wrap gap-1"
+                        >
+                            <button
+                                v-for="tag in selectedThread.tags"
+                                :key="tag"
+                                type="button"
+                                class="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                                :title="`Remove ${tag}`"
+                                @click="removeTag(tag)"
+                            >
+                                #{{ tag }} ×
+                            </button>
+                        </div>
                         <p
                             v-if="selectedThread.active_viewers.length"
                             class="mt-1 truncate text-[10.5px] font-semibold text-amber-500"
@@ -982,6 +1222,26 @@ function participantSummary(thread: ThreadRow): string {
                         <option value="pending">Pending</option>
                         <option value="closed">Closed</option>
                     </select>
+                    <form
+                        class="hidden items-center gap-1 2xl:flex"
+                        @submit.prevent="addTag"
+                    >
+                        <Tag class="size-3.5 text-zinc-400" />
+                        <input
+                            v-model="tagInput"
+                            maxlength="32"
+                            placeholder="tag"
+                            class="h-8 w-20 rounded-md border border-zinc-200 bg-transparent px-2 text-xs dark:border-[#1d2125]"
+                        />
+                    </form>
+                    <button
+                        type="button"
+                        class="grid size-8 place-items-center rounded-md border border-zinc-200 text-zinc-500 dark:border-[#1d2125]"
+                        title="Activity history"
+                        @click="showActivity = true"
+                    >
+                        <History class="size-3.5" />
+                    </button>
                     <select
                         :value="selectedThread.assigned_to?.id ?? ''"
                         class="hidden h-8 max-w-36 rounded-md border border-zinc-200 bg-transparent px-2 text-xs lg:block dark:border-[#1d2125]"
@@ -1363,6 +1623,29 @@ function participantSummary(thread: ThreadRow): string {
                                 @update:text="replyForm.text = $event"
                                 @submit="sendReply"
                             />
+                            <div class="grid gap-2 sm:grid-cols-3">
+                                <label
+                                    class="flex items-center gap-2 text-xs text-zinc-500"
+                                >
+                                    <input
+                                        v-model="replyForm.reply_all"
+                                        type="checkbox"
+                                    />
+                                    Reply all
+                                </label>
+                                <input
+                                    v-model="replyForm.cc"
+                                    type="text"
+                                    placeholder="CC"
+                                    class="h-8 rounded-md border border-zinc-200 bg-transparent px-2 text-xs dark:border-[#1d2125]"
+                                />
+                                <input
+                                    v-model="replyForm.bcc"
+                                    type="text"
+                                    placeholder="BCC"
+                                    class="h-8 rounded-md border border-zinc-200 bg-transparent px-2 text-xs dark:border-[#1d2125]"
+                                />
+                            </div>
                             <div
                                 v-if="replyForm.attachments.length"
                                 class="flex flex-wrap gap-2"
@@ -1607,9 +1890,9 @@ function participantSummary(thread: ThreadRow): string {
                     <span class="text-zinc-500">To</span>
                     <input
                         v-model="composeForm.to"
-                        type="email"
+                        type="text"
                         required
-                        placeholder="person@example.com"
+                        placeholder="One or more comma-separated addresses"
                         class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#1d2125] dark:bg-[#101111]"
                     />
                     <span
@@ -1796,6 +2079,95 @@ function participantSummary(thread: ThreadRow): string {
                 </div>
             </form>
         </div>
+    </div>
+    <div
+        v-if="showActivity && selectedThread"
+        class="fixed inset-0 z-50 grid place-items-center bg-zinc-950/45 p-4 backdrop-blur-sm"
+        @click.self="showActivity = false"
+    >
+        <section
+            class="grid max-h-[80vh] w-full max-w-lg grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-2xl dark:border-[#1d2125] dark:bg-[#111315]"
+        >
+            <div
+                class="flex items-center border-b border-zinc-200 p-4 dark:border-[#1d2125]"
+            >
+                <div>
+                    <h2 class="font-semibold">Conversation activity</h2>
+                    <p class="text-xs text-zinc-500">
+                        Assignment, status, snooze, and archive history
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    class="ml-auto p-2"
+                    aria-label="Close activity"
+                    @click="showActivity = false"
+                >
+                    <X class="size-4" />
+                </button>
+            </div>
+            <div class="overflow-y-auto p-4">
+                <form class="mb-4 flex gap-2" @submit.prevent="addTag">
+                    <div class="relative min-w-0 flex-1">
+                        <Tag
+                            class="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-400"
+                        />
+                        <input
+                            v-model="tagInput"
+                            maxlength="32"
+                            placeholder="Add a conversation tag"
+                            class="h-9 w-full rounded-md border border-zinc-200 bg-transparent pr-3 pl-8 text-sm dark:border-[#1d2125]"
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        class="rounded-md bg-teal-300 px-3 text-xs font-bold text-zinc-950 disabled:opacity-50"
+                        :disabled="!tagInput.trim()"
+                    >
+                        Add tag
+                    </button>
+                </form>
+                <div
+                    v-if="selectedThread.tags.length"
+                    class="mb-4 flex flex-wrap gap-1.5"
+                >
+                    <button
+                        v-for="tag in selectedThread.tags"
+                        :key="tag"
+                        type="button"
+                        class="rounded bg-zinc-100 px-2 py-1 text-xs dark:bg-zinc-800"
+                        @click="removeTag(tag)"
+                    >
+                        #{{ tag }} ×
+                    </button>
+                </div>
+                <p
+                    v-if="!selectedThread.activity.length"
+                    class="py-8 text-center text-sm text-zinc-500"
+                >
+                    No workflow activity yet.
+                </p>
+                <div
+                    v-for="event in selectedThread.activity"
+                    :key="event.id"
+                    class="flex gap-3 border-b border-zinc-100 py-3 last:border-0 dark:border-[#1d2125]"
+                >
+                    <span
+                        class="grid size-7 shrink-0 place-items-center rounded-full bg-zinc-100 font-mono text-[10px] dark:bg-zinc-800"
+                        >{{ event.actor.slice(0, 2).toUpperCase() }}</span
+                    >
+                    <div class="min-w-0 flex-1">
+                        <p class="text-sm">
+                            <strong>{{ event.actor }}</strong>
+                            {{ event.type.replaceAll('_', ' ') }}
+                        </p>
+                        <p class="font-mono text-[10.5px] text-zinc-500">
+                            {{ event.at_human }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </section>
     </div>
     <div
         v-if="showShortcuts"

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -28,6 +28,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import GlobalRail from '@/components/GlobalRail.vue';
 import RichTextEditor from '@/components/RichTextEditor.vue';
 import { Toaster } from '@/components/ui/sonner';
+import { inbox as inboxRoute } from '@/routes/projects';
 
 type ThreadRow = {
     public_id: string;
@@ -137,7 +138,7 @@ const tagInput = ref('');
 const notificationsEnabled = ref(false);
 let searchTimer: ReturnType<typeof window.setTimeout> | null = null;
 
-const inboxPath = computed(() => `${props.project.path}/inbox`);
+const inboxPath = computed(() => inboxRoute.url(props.project.slug));
 
 const mailboxes = computed(() => [
     {
@@ -197,12 +198,15 @@ function visitInbox(params: Record<string, string | null>): void {
 }
 
 function openMailbox(key: string): void {
-    visitInbox({ mailbox: key, thread: null });
+    visitInbox({ mailbox: key, address: null, thread: null });
 }
 
 function filterAddress(address: string): void {
+    const isSelected = props.address === address;
+
     visitInbox({
-        address: props.address === address ? null : address,
+        mailbox: isSelected ? 'inbox' : 'all',
+        address: isSelected ? null : address,
         thread: null,
     });
 }
@@ -339,6 +343,10 @@ const emptyMessage = computed(() => {
         return 'No conversations match your search.';
     }
 
+    if (props.address) {
+        return `No conversations for ${props.address}.`;
+    }
+
     if (props.mailbox === 'unread') {
         return 'You are caught up. There are no unread conversations.';
     }
@@ -455,7 +463,10 @@ onBeforeUnmount(() => {
 
 usePoll(
     10000,
-    { only: ['threads', 'counts', 'selectedThread'], showProgress: false },
+    {
+        only: ['threads', 'counts', 'addresses', 'selectedThread'],
+        showProgress: false,
+    },
     { autoStart: true },
 );
 

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -974,7 +974,7 @@ function participantSummary(thread: ThreadRow): string {
                             </span>
                             <select
                                 :value="filters.assigned"
-                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 text-[11.5px] font-medium text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#262a2e] dark:bg-[#16191c] dark:text-zinc-200"
+                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 text-[11.5px] font-medium text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                                 @change="setAssignmentFilter"
                             >
                                 <option value="">Any assignee</option>
@@ -994,7 +994,7 @@ function participantSummary(thread: ThreadRow): string {
                             </span>
                             <select
                                 :value="address ?? ''"
-                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 font-mono text-[10.5px] text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#262a2e] dark:bg-[#16191c] dark:text-zinc-200"
+                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 font-mono text-[10.5px] text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                                 @change="setAddressFilter"
                             >
                                 <option value="">All addresses</option>
@@ -1084,7 +1084,7 @@ function participantSummary(thread: ThreadRow): string {
                             Close
                         </button>
                         <select
-                            class="h-7 rounded border border-zinc-200 bg-transparent px-1 dark:border-[#1d2125]"
+                            class="h-7 rounded-md border border-zinc-200 bg-white px-2 text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                             :disabled="!selectedThreadIds.length"
                             @change="
                                 bulkAction(
@@ -1292,7 +1292,7 @@ function participantSummary(thread: ThreadRow): string {
                     </div>
                     <select
                         :value="selectedThread.status"
-                        class="hidden h-8 rounded-md border border-zinc-200 bg-transparent px-2 text-xs font-semibold lg:block dark:border-[#1d2125]"
+                        class="hidden h-8 rounded-md border border-zinc-200 bg-white px-2 text-xs font-semibold text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 lg:block dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                         aria-label="Conversation status"
                         @change="
                             updateWorkflow({
@@ -1327,7 +1327,7 @@ function participantSummary(thread: ThreadRow): string {
                     </button>
                     <select
                         :value="selectedThread.assigned_to?.id ?? ''"
-                        class="hidden h-8 max-w-36 rounded-md border border-zinc-200 bg-transparent px-2 text-xs lg:block dark:border-[#1d2125]"
+                        class="hidden h-8 max-w-36 rounded-md border border-zinc-200 bg-white px-2 text-xs text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 lg:block dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                         aria-label="Assign conversation"
                         @change="
                             updateWorkflow({
@@ -1353,7 +1353,7 @@ function participantSummary(thread: ThreadRow): string {
                     </select>
                     <select
                         :value="selectedThread.priority"
-                        class="hidden h-8 rounded-md border border-zinc-200 bg-transparent px-2 text-xs lg:block dark:border-[#1d2125]"
+                        class="hidden h-8 rounded-md border border-zinc-200 bg-white px-2 text-xs text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 lg:block dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                         aria-label="Conversation priority"
                         @change="
                             updateWorkflow({
@@ -1957,7 +1957,7 @@ function participantSummary(thread: ThreadRow): string {
                     <span class="text-zinc-500">From</span>
                     <select
                         v-model="composeForm.from"
-                        class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] dark:border-[#1d2125] dark:bg-[#101111]"
+                        class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                     >
                         <option value="">Default sender</option>
                         <option
@@ -1996,7 +1996,7 @@ function participantSummary(thread: ThreadRow): string {
                 <label v-if="templates.length" class="grid gap-1.5 text-sm">
                     <span class="text-zinc-500">Template</span>
                     <select
-                        class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] dark:border-[#1d2125] dark:bg-[#101111]"
+                        class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
                         @change="
                             applyTemplate(
                                 ($event.target as HTMLSelectElement).value,

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -16,6 +16,7 @@ import {
     Reply,
     Search,
     Send,
+    SlidersHorizontal,
     StickyNote,
     X,
 } from 'lucide-vue-next';
@@ -37,6 +38,10 @@ type ThreadRow = {
     snoozed_until_human: string | null;
     last_activity_at: string | null;
     last_activity_human: string | null;
+    status: 'open' | 'pending' | 'closed';
+    priority: 'low' | 'normal' | 'high' | 'urgent';
+    tags: string[];
+    assigned_to: { id: number; name: string } | null;
 };
 
 type Message = {
@@ -54,6 +59,8 @@ type Message = {
         size: number;
     }[];
     status: string | null;
+    status_detail?: string | null;
+    can_retry?: boolean;
     at: string | null;
     at_human: string | null;
 };
@@ -74,25 +81,40 @@ const props = defineProps<{
         href: string;
     }[];
     canSend: boolean;
+    teamMembers: { id: number; name: string; email: string }[];
+    templates: {
+        id: number;
+        name: string;
+        subject: string;
+        html: string | null;
+        text: string | null;
+    }[];
     mailbox: string;
     address: string | null;
-    filters: { q: string };
+    filters: { q: string; assigned: string };
     addresses: { address: string; count: number }[];
     counts: {
         inbox: number;
         unread: number;
         snoozed: number;
         archived: number;
+        closed: number;
     };
     threads: ThreadRow[];
+    pagination: { page: number; has_more: boolean };
     selectedThread:
-        | (ThreadRow & { messages: Message[]; reply_from: string | null })
+        | (ThreadRow & {
+              messages: Message[];
+              reply_from: string | null;
+              active_viewers: { id: number; name: string }[];
+          })
         | null;
 }>();
 
 const searchQuery = ref(props.filters.q);
 const searchInput = ref<HTMLInputElement | null>(null);
 const mobileThreadOpen = ref(false);
+const showFilters = ref(false);
 let searchTimer: ReturnType<typeof window.setTimeout> | null = null;
 
 const inboxPath = computed(() => `${props.project.path}/inbox`);
@@ -117,6 +139,7 @@ const mailboxes = computed(() => [
         icon: Archive,
         count: null,
     },
+    { key: 'closed', label: 'Closed', icon: ArchiveRestore, count: null },
 ]);
 
 const pageTitle = computed(() =>
@@ -135,6 +158,7 @@ function visitInbox(params: Record<string, string | null>): void {
         mailbox: props.mailbox,
         address: props.address,
         q: searchQuery.value,
+        assigned: props.filters.assigned,
         thread: props.selectedThread?.public_id ?? null,
         ...params,
     };
@@ -163,6 +187,13 @@ function filterAddress(address: string): void {
     });
 }
 
+function filterAssignment(assigned: string): void {
+    visitInbox({
+        assigned: props.filters.assigned === assigned ? null : assigned,
+        thread: null,
+    });
+}
+
 function openThread(publicId: string): void {
     mobileThreadOpen.value = true;
     visitInbox({ thread: publicId });
@@ -187,6 +218,46 @@ function threadAction(action: string): void {
         { preserveState: false, preserveScroll: true, showProgress: false },
     );
 }
+
+function updateWorkflow(data: Record<string, string | number | null>): void {
+    if (!props.selectedThread) {
+        return;
+    }
+
+    router.patch(
+        `${props.project.path}/threads/${props.selectedThread.public_id}/workflow`,
+        data,
+        { preserveScroll: true, showProgress: false },
+    );
+}
+
+function retryMessage(messageId: string): void {
+    router.post(
+        `${props.project.path}/emails/${messageId}/resend`,
+        {},
+        { preserveScroll: true },
+    );
+}
+
+const emptyMessage = computed(() => {
+    if (searchQuery.value) {
+        return 'No conversations match your search.';
+    }
+
+    if (props.mailbox === 'unread') {
+        return 'You are caught up. There are no unread conversations.';
+    }
+
+    if (props.mailbox === 'snoozed') {
+        return 'No conversations are snoozed.';
+    }
+
+    if (props.mailbox === 'archived') {
+        return 'No archived conversations.';
+    }
+
+    return 'Mail sent to your receiving addresses lands here.';
+});
 
 const selectedIndex = computed(() =>
     props.threads.findIndex(
@@ -275,7 +346,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
 
 usePoll(
     10000,
-    { only: ['threads', 'counts'], showProgress: false },
+    { only: ['threads', 'counts', 'selectedThread'], showProgress: false },
     { autoStart: true },
 );
 
@@ -315,6 +386,8 @@ const showCompose = ref(false);
 const composeForm = useForm({
     from: '',
     to: '',
+    cc: '',
+    bcc: '',
     subject: '',
     text: '',
     html: '',
@@ -329,6 +402,20 @@ function sendCompose(): void {
             localStorage.removeItem(draftKey('compose'));
         },
     });
+}
+
+function applyTemplate(templateId: string): void {
+    const template = props.templates.find(
+        (item) => item.id === Number(templateId),
+    );
+
+    if (!template) {
+        return;
+    }
+
+    composeForm.subject = template.subject;
+    composeForm.html = template.html ?? '';
+    composeForm.text = template.text ?? '';
 }
 
 const showForward = ref(false);
@@ -498,7 +585,14 @@ watch(
 // document gives foreign markup native typography; the load handler sizes
 // the frame to its content so short messages stay short.
 function messageDocument(html: string): string {
-    return `<!doctype html><html><head><meta charset="utf-8"><style>
+    const safeHtml = html
+        .replace(
+            /<img\b[^>]*>/gi,
+            '<span style="color:#71717a">[remote image blocked]</span>',
+        )
+        .replace(/<a\s/gi, '<a target="_blank" rel="noopener noreferrer" ');
+
+    return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data: cid:"><style>
 body{margin:0;padding:1px;font:13px/1.6 ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#27272a;word-break:break-word;overflow-wrap:anywhere}
 img{max-width:100%;height:auto}
 p{margin:0 0 .6em}p:last-child{margin-bottom:0}
@@ -507,7 +601,7 @@ blockquote{margin:0 0 .6em;padding-left:.8em;border-left:2px solid #99f6e4;color
 pre{white-space:pre-wrap;font:12px/1.6 ui-monospace,monospace}
 a{color:#0d9488}
 table{max-width:100%}
-</style></head><body>${html}</body></html>`;
+</style></head><body>${safeHtml}</body></html>`;
 }
 
 function fitMessageFrame(event: Event): void {
@@ -590,9 +684,17 @@ function participantSummary(thread: ThreadRow): string {
                 >
             </div>
             <button
+                type="button"
+                class="ml-auto grid size-9 place-items-center rounded-lg border border-zinc-200 text-zinc-500 xl:hidden dark:border-[#1d2125]"
+                aria-label="Mailbox filters"
+                @click="showFilters = true"
+            >
+                <SlidersHorizontal class="size-4" />
+            </button>
+            <button
                 v-if="canSend"
                 type="button"
-                class="ml-auto inline-flex h-9 items-center gap-2 rounded-lg bg-teal-300 px-3 text-[13px] font-bold text-zinc-950 transition hover:brightness-105"
+                class="inline-flex h-9 items-center gap-2 rounded-lg bg-teal-300 px-3 text-[13px] font-bold text-zinc-950 transition hover:brightness-105 xl:ml-auto"
                 @click="showCompose = true"
             >
                 <PenSquare class="size-3.5" />
@@ -643,6 +745,29 @@ function participantSummary(thread: ThreadRow): string {
                 </button>
 
                 <p
+                    class="px-2 pt-4 pb-1 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
+                >
+                    Assignment
+                </p>
+                <button
+                    v-for="entry in [
+                        { key: 'mine', label: 'Mine' },
+                        { key: 'unassigned', label: 'Unassigned' },
+                    ]"
+                    :key="entry.key"
+                    type="button"
+                    class="rounded-md px-2 py-1.5 text-left"
+                    :class="
+                        filters.assigned === entry.key
+                            ? 'bg-teal-50 dark:bg-teal-400/10'
+                            : 'text-zinc-600 dark:text-zinc-400'
+                    "
+                    @click="filterAssignment(entry.key)"
+                >
+                    {{ entry.label }}
+                </button>
+
+                <p
                     v-if="addresses.length"
                     class="px-2 pt-4 pb-1 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
                 >
@@ -664,7 +789,7 @@ function participantSummary(thread: ThreadRow): string {
                     <span
                         class="min-w-0 flex-1 truncate font-mono text-[11.5px]"
                     >
-                        {{ entry.address.split('@')[0] }}
+                        {{ entry.address }}
                     </span>
                     <span class="font-mono text-[10.5px] text-zinc-500">
                         {{ entry.count }}
@@ -703,7 +828,7 @@ function participantSummary(thread: ThreadRow): string {
                     >
                         <span class="font-semibold">No conversations</span>
                         <span class="text-xs">
-                            Mail sent to your receiving addresses lands here.
+                            {{ emptyMessage }}
                         </span>
                     </div>
                     <button
@@ -773,6 +898,37 @@ function participantSummary(thread: ThreadRow): string {
                             </span>
                         </div>
                     </button>
+                    <div
+                        v-if="pagination.page > 1 || pagination.has_more"
+                        class="flex gap-2 p-3"
+                    >
+                        <button
+                            v-if="pagination.page > 1"
+                            type="button"
+                            class="flex-1 rounded-md border border-zinc-200 py-2 text-xs font-semibold dark:border-[#1d2125]"
+                            @click="
+                                visitInbox({
+                                    page: String(pagination.page - 1),
+                                    thread: null,
+                                })
+                            "
+                        >
+                            Previous
+                        </button>
+                        <button
+                            v-if="pagination.has_more"
+                            type="button"
+                            class="flex-1 rounded-md border border-zinc-200 py-2 text-xs font-semibold dark:border-[#1d2125]"
+                            @click="
+                                visitInbox({
+                                    page: String(pagination.page + 1),
+                                    thread: null,
+                                })
+                            "
+                        >
+                            Next 50
+                        </button>
+                    </div>
                 </div>
             </section>
 
@@ -782,7 +938,7 @@ function participantSummary(thread: ThreadRow): string {
                 :class="mobileThreadOpen ? 'grid' : 'hidden'"
             >
                 <div
-                    class="flex items-center gap-2 border-b border-zinc-200 px-3 py-3 sm:gap-3 sm:px-5 dark:border-[#1d2125]"
+                    class="flex flex-wrap items-center gap-2 border-b border-zinc-200 px-3 py-3 sm:gap-3 sm:px-5 dark:border-[#1d2125]"
                 >
                     <button
                         type="button"
@@ -792,14 +948,82 @@ function participantSummary(thread: ThreadRow): string {
                     >
                         <ArrowLeft class="size-4" />
                     </button>
-                    <div class="min-w-0 flex-1">
+                    <div class="min-w-0 flex-1 md:basis-full 2xl:basis-auto">
                         <h1 class="truncate text-[15px] font-semibold">
                             {{ selectedThread.subject || '(no subject)' }}
                         </h1>
                         <p class="truncate font-mono text-[11px] text-zinc-500">
                             {{ selectedThread.participants.join(' · ') }}
                         </p>
+                        <p
+                            v-if="selectedThread.active_viewers.length"
+                            class="mt-1 truncate text-[10.5px] font-semibold text-amber-500"
+                        >
+                            {{
+                                selectedThread.active_viewers
+                                    .map((viewer) => viewer.name)
+                                    .join(', ')
+                            }}
+                            viewing now
+                        </p>
                     </div>
+                    <select
+                        :value="selectedThread.status"
+                        class="hidden h-8 rounded-md border border-zinc-200 bg-transparent px-2 text-xs font-semibold lg:block dark:border-[#1d2125]"
+                        aria-label="Conversation status"
+                        @change="
+                            updateWorkflow({
+                                status: ($event.target as HTMLSelectElement)
+                                    .value,
+                            })
+                        "
+                    >
+                        <option value="open">Open</option>
+                        <option value="pending">Pending</option>
+                        <option value="closed">Closed</option>
+                    </select>
+                    <select
+                        :value="selectedThread.assigned_to?.id ?? ''"
+                        class="hidden h-8 max-w-36 rounded-md border border-zinc-200 bg-transparent px-2 text-xs lg:block dark:border-[#1d2125]"
+                        aria-label="Assign conversation"
+                        @change="
+                            updateWorkflow({
+                                assigned_to_user_id: (
+                                    $event.target as HTMLSelectElement
+                                ).value
+                                    ? Number(
+                                          ($event.target as HTMLSelectElement)
+                                              .value,
+                                      )
+                                    : null,
+                            })
+                        "
+                    >
+                        <option value="">Unassigned</option>
+                        <option
+                            v-for="member in teamMembers"
+                            :key="member.id"
+                            :value="member.id"
+                        >
+                            {{ member.name }}
+                        </option>
+                    </select>
+                    <select
+                        :value="selectedThread.priority"
+                        class="hidden h-8 rounded-md border border-zinc-200 bg-transparent px-2 text-xs lg:block dark:border-[#1d2125]"
+                        aria-label="Conversation priority"
+                        @change="
+                            updateWorkflow({
+                                priority: ($event.target as HTMLSelectElement)
+                                    .value,
+                            })
+                        "
+                    >
+                        <option value="low">Low</option>
+                        <option value="normal">Normal</option>
+                        <option value="high">High</option>
+                        <option value="urgent">Urgent</option>
+                    </select>
                     <button
                         type="button"
                         class="hidden items-center gap-1.5 rounded-md border border-zinc-200 px-2.5 py-1.5 text-xs font-semibold text-zinc-600 transition hover:bg-zinc-100 2xl:inline-flex dark:border-[#1d2125] dark:text-zinc-300 dark:hover:bg-[#16191c]"
@@ -1021,6 +1245,20 @@ function participantSummary(thread: ThreadRow): string {
                                 {{ message.at_human }}
                             </span>
                         </div>
+                        <p
+                            v-if="message.status_detail"
+                            class="rounded-md bg-red-50 px-2 py-1 text-xs text-red-700 dark:bg-red-500/10 dark:text-red-300"
+                        >
+                            {{ message.status_detail }}
+                        </p>
+                        <button
+                            v-if="message.can_retry"
+                            type="button"
+                            class="w-fit rounded-md border border-red-200 px-2 py-1 text-xs font-semibold text-red-600 dark:border-red-500/30 dark:text-red-300"
+                            @click="retryMessage(message.id)"
+                        >
+                            Retry send
+                        </button>
                         <div
                             v-if="message.direction !== 'note'"
                             class="font-mono text-[10.5px] text-zinc-500"
@@ -1030,7 +1268,7 @@ function participantSummary(thread: ThreadRow): string {
                         <iframe
                             v-if="message.html"
                             :srcdoc="messageDocument(message.html)"
-                            sandbox="allow-same-origin"
+                            sandbox="allow-same-origin allow-popups"
                             class="h-6 w-full rounded-md bg-white"
                             :title="`Message from ${message.from_email}`"
                             @load="fitMessageFrame"
@@ -1044,17 +1282,31 @@ function participantSummary(thread: ThreadRow): string {
                             v-if="message.attachments.length"
                             class="flex flex-wrap gap-2"
                         >
-                            <a
+                            <template v-if="message.direction === 'inbound'">
+                                <a
+                                    v-for="(
+                                        attachment, index
+                                    ) in message.attachments"
+                                    :key="attachment.filename ?? index"
+                                    :href="attachmentUrl(message.id, index)"
+                                    class="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 px-2 py-1 font-mono text-[11px] text-zinc-600 transition hover:border-teal-300 hover:text-zinc-950 dark:border-[#1d2125] dark:text-zinc-400 dark:hover:text-zinc-100"
+                                >
+                                    <Paperclip class="size-3" />
+                                    {{ attachment.filename ?? 'attachment' }}
+                                </a>
+                            </template>
+                            <span
                                 v-for="(
                                     attachment, index
-                                ) in message.attachments"
-                                :key="attachment.filename ?? index"
-                                :href="attachmentUrl(message.id, index)"
-                                class="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 px-2 py-1 font-mono text-[11px] text-zinc-600 transition hover:border-teal-300 hover:text-zinc-950 dark:border-[#1d2125] dark:text-zinc-400 dark:hover:text-zinc-100"
+                                ) in message.direction === 'outbound'
+                                    ? message.attachments
+                                    : []"
+                                :key="`outbound-${attachment.filename ?? index}`"
+                                class="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 px-2 py-1 font-mono text-[11px] text-zinc-600 dark:border-[#1d2125] dark:text-zinc-400"
                             >
                                 <Paperclip class="size-3" />
                                 {{ attachment.filename ?? 'attachment' }}
-                            </a>
+                            </span>
                         </div>
                     </article>
                 </div>
@@ -1223,6 +1475,100 @@ function participantSummary(thread: ThreadRow): string {
         </div>
 
         <div
+            v-if="showFilters"
+            class="fixed inset-0 z-50 bg-zinc-950/45 xl:hidden"
+            @click.self="showFilters = false"
+        >
+            <aside
+                class="grid h-full w-72 content-start gap-1 overflow-y-auto bg-white p-4 shadow-2xl dark:bg-[#111315]"
+            >
+                <div class="mb-3 flex items-center">
+                    <h2 class="font-semibold">Mailbox filters</h2>
+                    <button
+                        type="button"
+                        class="ml-auto p-2"
+                        aria-label="Close filters"
+                        @click="showFilters = false"
+                    >
+                        <X class="size-4" />
+                    </button>
+                </div>
+                <button
+                    v-for="box in mailboxes"
+                    :key="box.key"
+                    type="button"
+                    class="flex min-h-10 items-center gap-2 rounded-lg px-3 text-left"
+                    :class="
+                        mailbox === box.key && !address
+                            ? 'bg-teal-50 dark:bg-teal-400/10'
+                            : ''
+                    "
+                    @click="
+                        showFilters = false;
+                        openMailbox(box.key);
+                    "
+                >
+                    <component :is="box.icon" class="size-4" />
+                    <span class="flex-1">{{ box.label }}</span>
+                    <span v-if="box.count" class="font-mono text-xs">{{
+                        box.count
+                    }}</span>
+                </button>
+                <p
+                    class="mt-4 px-3 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
+                >
+                    Assignment
+                </p>
+                <button
+                    v-for="entry in [
+                        { key: 'mine', label: 'Mine' },
+                        { key: 'unassigned', label: 'Unassigned' },
+                    ]"
+                    :key="entry.key"
+                    type="button"
+                    class="min-h-10 rounded-lg px-3 text-left"
+                    :class="
+                        filters.assigned === entry.key
+                            ? 'bg-teal-50 dark:bg-teal-400/10'
+                            : ''
+                    "
+                    @click="
+                        showFilters = false;
+                        filterAssignment(entry.key);
+                    "
+                >
+                    {{ entry.label }}
+                </button>
+                <p
+                    class="mt-4 px-3 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
+                >
+                    Addresses
+                </p>
+                <button
+                    v-for="entry in addresses"
+                    :key="entry.address"
+                    type="button"
+                    class="flex min-h-10 items-center gap-2 rounded-lg px-3 text-left"
+                    :class="
+                        address === entry.address
+                            ? 'bg-teal-50 dark:bg-teal-400/10'
+                            : ''
+                    "
+                    @click="
+                        showFilters = false;
+                        filterAddress(entry.address);
+                    "
+                >
+                    <AtSign class="size-4" />
+                    <span class="min-w-0 flex-1 truncate">{{
+                        entry.address
+                    }}</span>
+                    <span class="font-mono text-xs">{{ entry.count }}</span>
+                </button>
+            </aside>
+        </div>
+
+        <div
             v-if="showCompose"
             class="fixed inset-0 z-40 grid place-items-center bg-zinc-950/40 p-4 backdrop-blur-sm"
             @click.self="showCompose = false"
@@ -1241,6 +1587,22 @@ function participantSummary(thread: ThreadRow): string {
                         <X class="size-4" />
                     </button>
                 </div>
+                <label class="grid gap-1.5 text-sm">
+                    <span class="text-zinc-500">From</span>
+                    <select
+                        v-model="composeForm.from"
+                        class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] dark:border-[#1d2125] dark:bg-[#101111]"
+                    >
+                        <option value="">Default sender</option>
+                        <option
+                            v-for="entry in addresses"
+                            :key="entry.address"
+                            :value="entry.address"
+                        >
+                            {{ entry.address }}
+                        </option>
+                    </select>
+                </label>
                 <label class="grid gap-1.5 text-sm">
                     <span class="text-zinc-500">To</span>
                     <input
@@ -1265,6 +1627,46 @@ function participantSummary(thread: ThreadRow): string {
                         class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#1d2125] dark:bg-[#101111]"
                     />
                 </label>
+                <label v-if="templates.length" class="grid gap-1.5 text-sm">
+                    <span class="text-zinc-500">Template</span>
+                    <select
+                        class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] dark:border-[#1d2125] dark:bg-[#101111]"
+                        @change="
+                            applyTemplate(
+                                ($event.target as HTMLSelectElement).value,
+                            )
+                        "
+                    >
+                        <option value="">Start from scratch</option>
+                        <option
+                            v-for="template in templates"
+                            :key="template.id"
+                            :value="template.id"
+                        >
+                            {{ template.name }}
+                        </option>
+                    </select>
+                </label>
+                <div class="grid gap-3 sm:grid-cols-2">
+                    <label class="grid gap-1.5 text-sm">
+                        <span class="text-zinc-500">CC</span>
+                        <input
+                            v-model="composeForm.cc"
+                            type="text"
+                            placeholder="Comma-separated addresses"
+                            class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] dark:border-[#1d2125] dark:bg-[#101111]"
+                        />
+                    </label>
+                    <label class="grid gap-1.5 text-sm">
+                        <span class="text-zinc-500">BCC</span>
+                        <input
+                            v-model="composeForm.bcc"
+                            type="text"
+                            placeholder="Comma-separated addresses"
+                            class="h-9 rounded-md border border-zinc-200 bg-white px-2.5 text-[13px] dark:border-[#1d2125] dark:bg-[#101111]"
+                        />
+                    </label>
+                </div>
                 <div class="grid gap-1.5 text-sm">
                     <span class="text-zinc-500">Message</span>
                     <RichTextEditor

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -122,6 +122,10 @@ const props = defineProps<{
         | null;
 }>();
 
+const isDarkMode = ref(false);
+const isThemeReady = ref(false);
+let themeObserver: MutationObserver | null = null;
+
 const searchQuery = ref(props.filters.q);
 const searchInput = ref<HTMLInputElement | null>(null);
 const mobileThreadOpen = ref(false);
@@ -428,6 +432,15 @@ function onKeydown(event: KeyboardEvent): void {
 }
 
 onMounted(() => {
+    isDarkMode.value = document.documentElement.classList.contains('dark');
+    isThemeReady.value = true;
+    themeObserver = new MutationObserver(() => {
+        isDarkMode.value = document.documentElement.classList.contains('dark');
+    });
+    themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+    });
     mobileThreadOpen.value = new URLSearchParams(window.location.search).has(
         'thread',
     );
@@ -435,7 +448,10 @@ onMounted(() => {
     notificationsEnabled.value =
         localStorage.getItem('larasend:inbox-notifications') === '1';
 });
-onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
+onBeforeUnmount(() => {
+    themeObserver?.disconnect();
+    window.removeEventListener('keydown', onKeydown);
+});
 
 usePoll(
     10000,
@@ -702,7 +718,7 @@ watch(
 // Message HTML renders inside a sandboxed iframe (no scripts). The wrapper
 // document gives foreign markup native typography; the load handler sizes
 // the frame to its content so short messages stay short.
-function messageDocument(html: string): string {
+function messageDocument(html: string, dark: boolean): string {
     const safeHtml = html
         .replace(
             /<img\b[^>]*>/gi,
@@ -710,14 +726,20 @@ function messageDocument(html: string): string {
         )
         .replace(/<a\s/gi, '<a target="_blank" rel="noopener noreferrer" ');
 
+    const foreground = dark ? '#e4e4e7' : '#27272a';
+    const muted = dark ? '#a1a1aa' : '#71717a';
+    const link = dark ? '#5eead4' : '#0d9488';
+
     return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data: cid:"><style>
-body{margin:0;padding:1px;font:13px/1.6 ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#27272a;word-break:break-word;overflow-wrap:anywhere}
+html{color-scheme:${dark ? 'dark' : 'light'};background:transparent}
+body{margin:0;padding:1px;background:transparent;font:13px/1.6 ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:${foreground};word-break:break-word;overflow-wrap:anywhere}
+${dark ? `body :where(p,div,span,td,th,li,pre,code,strong,em){color:${foreground}!important}` : ''}
 img{max-width:100%;height:auto}
 p{margin:0 0 .6em}p:last-child{margin-bottom:0}
 ul,ol{margin:0 0 .6em;padding-left:1.4em}
-blockquote{margin:0 0 .6em;padding-left:.8em;border-left:2px solid #99f6e4;color:#71717a}
+blockquote{margin:0 0 .6em;padding-left:.8em;border-left:2px solid #99f6e4;color:${muted}}
 pre{white-space:pre-wrap;font:12px/1.6 ui-monospace,monospace}
-a{color:#0d9488}
+a{color:${link}!important}
 table{max-width:100%}
 </style></head><body>${safeHtml}</body></html>`;
 }
@@ -1526,10 +1548,10 @@ function participantSummary(thread: ThreadRow): string {
                             to {{ message.to }}
                         </div>
                         <iframe
-                            v-if="message.html"
-                            :srcdoc="messageDocument(message.html)"
+                            v-if="message.html && isThemeReady"
+                            :srcdoc="messageDocument(message.html, isDarkMode)"
                             sandbox="allow-same-origin allow-popups"
-                            class="h-6 w-full rounded-md bg-white"
+                            class="h-6 w-full rounded-md bg-white dark:bg-[#101111]"
                             :title="`Message from ${message.from_email}`"
                             @load="fitMessageFrame"
                         />

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -206,34 +206,21 @@ function openMailbox(key: string): void {
 }
 
 function filterAddress(address: string): void {
-    const isSelected = props.address === address;
-
-    visitInbox({
-        mailbox: isSelected ? 'inbox' : 'all',
-        address: isSelected ? null : address,
-        thread: null,
-    });
+    setAddressFilter(props.address === address ? null : address);
 }
 
 function filterAssignment(assigned: string): void {
-    visitInbox({
-        assigned: props.filters.assigned === assigned ? null : assigned,
-        thread: null,
-    });
+    setAssignmentFilter(props.filters.assigned === assigned ? null : assigned);
 }
 
-function setAssignmentFilter(event: Event): void {
-    const assigned = (event.target as HTMLSelectElement).value;
-
-    visitInbox({ assigned: assigned || null, thread: null });
+function setAssignmentFilter(assigned: string | null): void {
+    visitInbox({ assigned, thread: null });
 }
 
-function setAddressFilter(event: Event): void {
-    const address = (event.target as HTMLSelectElement).value;
-
+function setAddressFilter(address: string | null): void {
     visitInbox({
         mailbox: address ? 'all' : 'inbox',
-        address: address || null,
+        address,
         thread: null,
     });
 }
@@ -963,50 +950,119 @@ function participantSummary(thread: ThreadRow): string {
                         </button>
                     </div>
 
-                    <div
-                        class="grid gap-2.5 rounded-lg border border-zinc-200 bg-zinc-50/70 p-2.5 dark:border-[#1d2125] dark:bg-[#101111]"
-                    >
-                        <label class="grid min-w-0 gap-1">
-                            <span
-                                class="text-[10.5px] font-medium text-zinc-500 dark:text-zinc-400"
+                    <div class="grid gap-3">
+                        <fieldset class="grid min-w-0 gap-1.5">
+                            <legend
+                                class="mb-1 text-[10.5px] font-medium text-zinc-500 dark:text-zinc-400"
                             >
                                 Assignee
-                            </span>
-                            <select
-                                :value="filters.assigned"
-                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 text-[11.5px] font-medium text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
-                                @change="setAssignmentFilter"
+                            </legend>
+                            <div
+                                class="grid grid-cols-[0.65fr_0.8fr_1.25fr] gap-0.5 rounded-lg bg-zinc-100 p-0.5 ring-1 ring-zinc-200 dark:bg-[#111315] dark:ring-[#25292d]"
+                                role="radiogroup"
+                                aria-label="Assignee filter"
                             >
-                                <option value="">Any assignee</option>
-                                <option value="mine">Assigned to me</option>
-                                <option value="unassigned">Unassigned</option>
-                            </select>
-                        </label>
+                                <button
+                                    v-for="entry in [
+                                        { key: null, label: 'All' },
+                                        { key: 'mine', label: 'Mine' },
+                                        {
+                                            key: 'unassigned',
+                                            label: 'Unassigned',
+                                        },
+                                    ]"
+                                    :key="entry.label"
+                                    type="button"
+                                    role="radio"
+                                    class="h-7 min-w-0 rounded-md px-1 text-[10.5px] font-semibold transition"
+                                    :class="
+                                        (filters.assigned || null) === entry.key
+                                            ? 'bg-white text-zinc-900 shadow-sm ring-1 ring-zinc-200 dark:bg-[#22262a] dark:text-zinc-100 dark:ring-[#30353a]'
+                                            : 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-200'
+                                    "
+                                    :aria-checked="
+                                        (filters.assigned || null) === entry.key
+                                    "
+                                    @click="setAssignmentFilter(entry.key)"
+                                >
+                                    {{ entry.label }}
+                                </button>
+                            </div>
+                        </fieldset>
 
-                        <label
+                        <fieldset
                             v-if="addresses.length"
-                            class="grid min-w-0 gap-1"
+                            class="grid min-w-0 gap-1.5"
                         >
-                            <span
-                                class="text-[10.5px] font-medium text-zinc-500 dark:text-zinc-400"
+                            <legend
+                                class="mb-1 text-[10.5px] font-medium text-zinc-500 dark:text-zinc-400"
                             >
                                 Receiving address
-                            </span>
-                            <select
-                                :value="address ?? ''"
-                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 font-mono text-[10.5px] text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#2a2e32] dark:bg-[#16191c] dark:text-zinc-100"
-                                @change="setAddressFilter"
+                            </legend>
+                            <div
+                                class="grid divide-y divide-zinc-200 overflow-hidden rounded-lg border border-zinc-200 bg-white dark:divide-[#25292d] dark:border-[#25292d] dark:bg-[#101111]"
+                                role="radiogroup"
+                                aria-label="Receiving address filter"
                             >
-                                <option value="">All addresses</option>
-                                <option
+                                <button
+                                    type="button"
+                                    role="radio"
+                                    class="flex h-9 min-w-0 items-center gap-2 px-2 text-left transition"
+                                    :class="
+                                        address === null
+                                            ? 'bg-teal-50 text-zinc-900 dark:bg-teal-400/10 dark:text-zinc-100'
+                                            : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:bg-[#16191c]'
+                                    "
+                                    :aria-checked="address === null"
+                                    @click="setAddressFilter(null)"
+                                >
+                                    <span
+                                        class="size-1.5 shrink-0 rounded-full"
+                                        :class="
+                                            address === null
+                                                ? 'bg-teal-500'
+                                                : 'bg-zinc-300 dark:bg-zinc-700'
+                                        "
+                                    />
+                                    <span
+                                        class="min-w-0 flex-1 truncate text-[11.5px] font-medium"
+                                    >
+                                        All addresses
+                                    </span>
+                                </button>
+                                <button
                                     v-for="entry in addresses"
                                     :key="entry.address"
-                                    :value="entry.address"
+                                    type="button"
+                                    role="radio"
+                                    class="flex h-10 min-w-0 items-center gap-2 px-2 text-left transition"
+                                    :class="
+                                        address === entry.address
+                                            ? 'bg-teal-50 text-zinc-900 dark:bg-teal-400/10 dark:text-zinc-100'
+                                            : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:bg-[#16191c]'
+                                    "
+                                    :aria-checked="address === entry.address"
+                                    @click="setAddressFilter(entry.address)"
                                 >
-                                    {{ entry.address }} · {{ entry.count }}
-                                </option>
-                            </select>
-                        </label>
+                                    <span
+                                        class="grid size-5 shrink-0 place-items-center rounded-md bg-zinc-100 dark:bg-[#1b1e21]"
+                                    >
+                                        <AtSign class="size-3" />
+                                    </span>
+                                    <span
+                                        class="min-w-0 flex-1 truncate font-mono text-[10.5px]"
+                                        :title="entry.address"
+                                    >
+                                        {{ entry.address }}
+                                    </span>
+                                    <span
+                                        class="grid min-w-4 shrink-0 place-items-center rounded-full bg-zinc-100 px-1 font-mono text-[9.5px] text-zinc-500 dark:bg-[#1b1e21] dark:text-zinc-400"
+                                    >
+                                        {{ entry.count }}
+                                    </span>
+                                </button>
+                            </div>
+                        </fieldset>
                     </div>
                 </section>
             </aside>

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -169,6 +169,10 @@ const pageTitle = computed(() =>
         : `Inbox · ${props.project.name}`,
 );
 
+const hasFilters = computed(() =>
+    Boolean(props.filters.assigned || props.address),
+);
+
 function visitInbox(params: Record<string, string | null>): void {
     if (params.thread === null) {
         mobileThreadOpen.value = false;
@@ -214,6 +218,31 @@ function filterAddress(address: string): void {
 function filterAssignment(assigned: string): void {
     visitInbox({
         assigned: props.filters.assigned === assigned ? null : assigned,
+        thread: null,
+    });
+}
+
+function setAssignmentFilter(event: Event): void {
+    const assigned = (event.target as HTMLSelectElement).value;
+
+    visitInbox({ assigned: assigned || null, thread: null });
+}
+
+function setAddressFilter(event: Event): void {
+    const address = (event.target as HTMLSelectElement).value;
+
+    visitInbox({
+        mailbox: address ? 'all' : 'inbox',
+        address: address || null,
+        thread: null,
+    });
+}
+
+function clearFilters(): void {
+    visitInbox({
+        mailbox: props.address ? 'inbox' : props.mailbox,
+        address: null,
+        assigned: null,
         thread: null,
     });
 }
@@ -913,72 +942,71 @@ function participantSummary(thread: ThreadRow): string {
                 <section
                     class="mt-4 border-t border-zinc-200 pt-4 dark:border-[#1d2125]"
                 >
-                    <p
-                        class="flex items-center gap-1.5 px-2 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
+                    <div class="mb-2.5 flex items-center gap-2 px-1">
+                        <span
+                            class="grid size-6 place-items-center rounded-md bg-zinc-100 text-zinc-500 dark:bg-[#16191c] dark:text-zinc-400"
+                        >
+                            <SlidersHorizontal class="size-3.5" />
+                        </span>
+                        <p
+                            class="text-[12.5px] font-semibold text-zinc-800 dark:text-zinc-200"
+                        >
+                            Filters
+                        </p>
+                        <button
+                            v-if="hasFilters"
+                            type="button"
+                            class="ml-auto rounded px-1 py-0.5 text-[10.5px] font-semibold text-teal-700 transition hover:bg-teal-50 dark:text-teal-300 dark:hover:bg-teal-400/10"
+                            @click="clearFilters"
+                        >
+                            Clear
+                        </button>
+                    </div>
+
+                    <div
+                        class="grid gap-2.5 rounded-lg border border-zinc-200 bg-zinc-50/70 p-2.5 dark:border-[#1d2125] dark:bg-[#101111]"
                     >
-                        <SlidersHorizontal class="size-3" />
-                        Filters
-                    </p>
-
-                    <div class="grid gap-3 pt-3">
-                        <div class="grid gap-0.5">
-                            <p
-                                class="px-2 pb-0.5 font-mono text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500"
+                        <label class="grid min-w-0 gap-1">
+                            <span
+                                class="text-[10.5px] font-medium text-zinc-500 dark:text-zinc-400"
                             >
-                                Assignment
-                            </p>
-                            <button
-                                v-for="entry in [
-                                    { key: 'mine', label: 'Mine' },
-                                    { key: 'unassigned', label: 'Unassigned' },
-                                ]"
-                                :key="entry.key"
-                                type="button"
-                                class="h-7 rounded-md px-2 text-left text-[12.5px] font-medium transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
-                                :class="
-                                    filters.assigned === entry.key
-                                        ? 'bg-teal-50 text-zinc-950 ring-1 ring-teal-200 dark:bg-teal-400/10 dark:text-zinc-100 dark:ring-teal-400/20'
-                                        : 'text-zinc-600 dark:text-zinc-400'
-                                "
-                                :aria-pressed="filters.assigned === entry.key"
-                                @click="filterAssignment(entry.key)"
+                                Assignee
+                            </span>
+                            <select
+                                :value="filters.assigned"
+                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 text-[11.5px] font-medium text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#262a2e] dark:bg-[#16191c] dark:text-zinc-200"
+                                @change="setAssignmentFilter"
                             >
-                                {{ entry.label }}
-                            </button>
-                        </div>
+                                <option value="">Any assignee</option>
+                                <option value="mine">Assigned to me</option>
+                                <option value="unassigned">Unassigned</option>
+                            </select>
+                        </label>
 
-                        <div v-if="addresses.length" class="grid gap-0.5">
-                            <p
-                                class="px-2 pb-0.5 font-mono text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500"
+                        <label
+                            v-if="addresses.length"
+                            class="grid min-w-0 gap-1"
+                        >
+                            <span
+                                class="text-[10.5px] font-medium text-zinc-500 dark:text-zinc-400"
                             >
                                 Receiving address
-                            </p>
-                            <button
-                                v-for="entry in addresses"
-                                :key="entry.address"
-                                type="button"
-                                class="flex h-7 min-w-0 items-center gap-2 rounded-md px-2 text-left transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
-                                :class="
-                                    address === entry.address
-                                        ? 'bg-teal-50 text-zinc-950 ring-1 ring-teal-200 dark:bg-teal-400/10 dark:text-zinc-100 dark:ring-teal-400/20'
-                                        : 'text-zinc-600 dark:text-zinc-400'
-                                "
-                                :aria-pressed="address === entry.address"
-                                @click="filterAddress(entry.address)"
+                            </span>
+                            <select
+                                :value="address ?? ''"
+                                class="h-8 min-w-0 rounded-md border border-zinc-200 bg-white px-2 font-mono text-[10.5px] text-zinc-700 transition outline-none focus:border-teal-400 focus:ring-2 focus:ring-teal-300/20 dark:border-[#262a2e] dark:bg-[#16191c] dark:text-zinc-200"
+                                @change="setAddressFilter"
                             >
-                                <AtSign class="size-3 shrink-0" />
-                                <span
-                                    class="min-w-0 flex-1 truncate font-mono text-[11.5px]"
+                                <option value="">All addresses</option>
+                                <option
+                                    v-for="entry in addresses"
+                                    :key="entry.address"
+                                    :value="entry.address"
                                 >
-                                    {{ entry.address }}
-                                </span>
-                                <span
-                                    class="font-mono text-[10.5px] text-zinc-500"
-                                >
-                                    {{ entry.count }}
-                                </span>
-                            </button>
-                        </div>
+                                    {{ entry.address }} · {{ entry.count }}
+                                </option>
+                            </select>
+                        </label>
                     </div>
                 </section>
             </aside>

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -881,84 +881,106 @@ function participantSummary(thread: ThreadRow): string {
             <aside
                 class="hidden min-h-0 content-start gap-1 overflow-auto border-r border-zinc-200 p-3 xl:grid dark:border-[#1d2125]"
             >
-                <p
-                    class="px-2 pb-1 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
-                >
-                    Mailboxes
-                </p>
-                <button
-                    v-for="box in mailboxes"
-                    :key="box.key"
-                    type="button"
-                    class="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left font-medium transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
-                    :class="
-                        mailbox === box.key && !address
-                            ? 'bg-teal-50 text-zinc-950 dark:bg-teal-400/10 dark:text-zinc-100'
-                            : 'text-zinc-600 dark:text-zinc-400'
-                    "
-                    @click="openMailbox(box.key)"
-                >
-                    <component :is="box.icon" class="size-3.5 shrink-0" />
-                    <span class="flex-1">{{ box.label }}</span>
-                    <span
-                        v-if="box.count"
-                        class="rounded-full bg-teal-300 px-1.5 font-mono text-[10.5px] font-semibold text-zinc-950"
+                <section class="grid gap-0.5">
+                    <p
+                        class="px-2 pb-1 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
                     >
-                        {{ box.count }}
-                    </span>
-                </button>
-
-                <p
-                    class="px-2 pt-4 pb-1 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
-                >
-                    Assignment
-                </p>
-                <button
-                    v-for="entry in [
-                        { key: 'mine', label: 'Mine' },
-                        { key: 'unassigned', label: 'Unassigned' },
-                    ]"
-                    :key="entry.key"
-                    type="button"
-                    class="rounded-md px-2 py-1.5 text-left"
-                    :class="
-                        filters.assigned === entry.key
-                            ? 'bg-teal-50 dark:bg-teal-400/10'
-                            : 'text-zinc-600 dark:text-zinc-400'
-                    "
-                    @click="filterAssignment(entry.key)"
-                >
-                    {{ entry.label }}
-                </button>
-
-                <p
-                    v-if="addresses.length"
-                    class="px-2 pt-4 pb-1 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
-                >
-                    Addresses
-                </p>
-                <button
-                    v-for="entry in addresses"
-                    :key="entry.address"
-                    type="button"
-                    class="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
-                    :class="
-                        address === entry.address
-                            ? 'bg-teal-50 text-zinc-950 dark:bg-teal-400/10 dark:text-zinc-100'
-                            : 'text-zinc-600 dark:text-zinc-400'
-                    "
-                    @click="filterAddress(entry.address)"
-                >
-                    <AtSign class="size-3 shrink-0" />
-                    <span
-                        class="min-w-0 flex-1 truncate font-mono text-[11.5px]"
+                        Mailboxes
+                    </p>
+                    <button
+                        v-for="box in mailboxes"
+                        :key="box.key"
+                        type="button"
+                        class="flex h-7 items-center gap-2.5 rounded-md px-2 text-left font-medium transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
+                        :class="
+                            mailbox === box.key && !address
+                                ? 'bg-teal-50 text-zinc-950 dark:bg-teal-400/10 dark:text-zinc-100'
+                                : 'text-zinc-600 dark:text-zinc-400'
+                        "
+                        @click="openMailbox(box.key)"
                     >
-                        {{ entry.address }}
-                    </span>
-                    <span class="font-mono text-[10.5px] text-zinc-500">
-                        {{ entry.count }}
-                    </span>
-                </button>
+                        <component :is="box.icon" class="size-3.5 shrink-0" />
+                        <span class="flex-1">{{ box.label }}</span>
+                        <span
+                            v-if="box.count"
+                            class="rounded-full bg-teal-300 px-1.5 font-mono text-[10.5px] font-semibold text-zinc-950"
+                        >
+                            {{ box.count }}
+                        </span>
+                    </button>
+                </section>
+
+                <section
+                    class="mt-4 border-t border-zinc-200 pt-4 dark:border-[#1d2125]"
+                >
+                    <p
+                        class="flex items-center gap-1.5 px-2 font-mono text-[10px] tracking-widest text-zinc-500 uppercase"
+                    >
+                        <SlidersHorizontal class="size-3" />
+                        Filters
+                    </p>
+
+                    <div class="grid gap-3 pt-3">
+                        <div class="grid gap-0.5">
+                            <p
+                                class="px-2 pb-0.5 font-mono text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500"
+                            >
+                                Assignment
+                            </p>
+                            <button
+                                v-for="entry in [
+                                    { key: 'mine', label: 'Mine' },
+                                    { key: 'unassigned', label: 'Unassigned' },
+                                ]"
+                                :key="entry.key"
+                                type="button"
+                                class="h-7 rounded-md px-2 text-left text-[12.5px] font-medium transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
+                                :class="
+                                    filters.assigned === entry.key
+                                        ? 'bg-teal-50 text-zinc-950 ring-1 ring-teal-200 dark:bg-teal-400/10 dark:text-zinc-100 dark:ring-teal-400/20'
+                                        : 'text-zinc-600 dark:text-zinc-400'
+                                "
+                                :aria-pressed="filters.assigned === entry.key"
+                                @click="filterAssignment(entry.key)"
+                            >
+                                {{ entry.label }}
+                            </button>
+                        </div>
+
+                        <div v-if="addresses.length" class="grid gap-0.5">
+                            <p
+                                class="px-2 pb-0.5 font-mono text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500"
+                            >
+                                Receiving address
+                            </p>
+                            <button
+                                v-for="entry in addresses"
+                                :key="entry.address"
+                                type="button"
+                                class="flex h-7 min-w-0 items-center gap-2 rounded-md px-2 text-left transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
+                                :class="
+                                    address === entry.address
+                                        ? 'bg-teal-50 text-zinc-950 ring-1 ring-teal-200 dark:bg-teal-400/10 dark:text-zinc-100 dark:ring-teal-400/20'
+                                        : 'text-zinc-600 dark:text-zinc-400'
+                                "
+                                :aria-pressed="address === entry.address"
+                                @click="filterAddress(entry.address)"
+                            >
+                                <AtSign class="size-3 shrink-0" />
+                                <span
+                                    class="min-w-0 flex-1 truncate font-mono text-[11.5px]"
+                                >
+                                    {{ entry.address }}
+                                </span>
+                                <span
+                                    class="font-mono text-[10.5px] text-zinc-500"
+                                >
+                                    {{ entry.count }}
+                                </span>
+                            </button>
+                        </div>
+                    </div>
+                </section>
             </aside>
 
             <section

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('threads/{thread:public_id}/snooze', [ThreadActionController::class, 'snooze'])->name('threads.snooze');
         Route::post('threads/{thread:public_id}/unsnooze', [ThreadActionController::class, 'unsnooze'])->name('threads.unsnooze');
         Route::post('threads/{thread:public_id}/notes', [ThreadActionController::class, 'storeNote'])->name('threads.notes.store');
+        Route::patch('threads/{thread:public_id}/workflow', [ThreadActionController::class, 'updateWorkflow'])->name('threads.workflow.update');
         Route::post('inbox/compose', [ThreadActionController::class, 'compose'])->name('inbox.compose');
         Route::get('inbound/{inboundEmail:public_id}/attachments/{index}', InboundAttachmentController::class)
             ->whereNumber('index')

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,6 +72,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('threads/{thread:public_id}/notes', [ThreadActionController::class, 'storeNote'])->name('threads.notes.store');
         Route::patch('threads/{thread:public_id}/workflow', [ThreadActionController::class, 'updateWorkflow'])->name('threads.workflow.update');
         Route::post('inbox/compose', [ThreadActionController::class, 'compose'])->name('inbox.compose');
+        Route::post('inbox/bulk', [ThreadActionController::class, 'bulk'])->name('inbox.bulk');
         Route::get('inbound/{inboundEmail:public_id}/attachments/{index}', InboundAttachmentController::class)
             ->whereNumber('index')
             ->name('inbound.attachments');

--- a/tests/Feature/InboxReplyTest.php
+++ b/tests/Feature/InboxReplyTest.php
@@ -109,6 +109,8 @@ it('starts a new conversation from the compose modal', function () {
     $this->actingAs($user)
         ->post("/projects/{$project->slug}/inbox/compose", [
             'to' => 'lead@customer.test',
+            'cc' => 'sales@customer.test, owner@customer.test',
+            'bcc' => 'audit@example.com',
             'subject' => 'Welcome aboard',
             'text' => 'Glad to have you!',
         ])
@@ -119,7 +121,9 @@ it('starts a new conversation from the compose modal', function () {
     expect($email->from_email)->toBe('support@example.com')
         ->and($email->thread)->not->toBeNull()
         ->and($email->thread->subject)->toBe('Welcome aboard')
-        ->and($email->thread->last_direction)->toBe('outbound');
+        ->and($email->thread->last_direction)->toBe('outbound')
+        ->and($email->recipients()->where('type', 'cc')->count())->toBe(2)
+        ->and($email->recipients()->where('type', 'bcc')->value('email'))->toBe('audit@example.com');
 });
 
 it('blocks replies from members without send permission', function () {

--- a/tests/Feature/InboxReplyTest.php
+++ b/tests/Feature/InboxReplyTest.php
@@ -108,7 +108,7 @@ it('starts a new conversation from the compose modal', function () {
 
     $this->actingAs($user)
         ->post("/projects/{$project->slug}/inbox/compose", [
-            'to' => 'lead@customer.test',
+            'to' => 'lead@customer.test, billing@customer.test',
             'cc' => 'sales@customer.test, owner@customer.test',
             'bcc' => 'audit@example.com',
             'subject' => 'Welcome aboard',
@@ -122,8 +122,29 @@ it('starts a new conversation from the compose modal', function () {
         ->and($email->thread)->not->toBeNull()
         ->and($email->thread->subject)->toBe('Welcome aboard')
         ->and($email->thread->last_direction)->toBe('outbound')
+        ->and($email->recipients()->where('type', 'to')->count())->toBe(2)
         ->and($email->recipients()->where('type', 'cc')->count())->toBe(2)
         ->and($email->recipients()->where('type', 'bcc')->value('email'))->toBe('audit@example.com');
+});
+
+it('replies to copied participants when reply all is selected', function () {
+    [$user, $project, $source] = replyFixture();
+    Queue::fake();
+    receiveReplyableEmail($this, $source);
+    $thread = Thread::query()->firstOrFail();
+    $inbound = InboundEmail::query()->firstOrFail();
+    $inbound->forceFill(['headers' => [...$inbound->headers, 'Cc' => 'finance@customer.test, support@example.com']])->save();
+
+    $this->actingAs($user)
+        ->post("/projects/{$project->slug}/threads/{$thread->public_id}/reply", [
+            'text' => 'Replying to everyone',
+            'reply_all' => true,
+        ])
+        ->assertRedirect();
+
+    $email = Email::query()->firstOrFail();
+    expect($email->recipients()->where('type', 'cc')->pluck('email')->all())
+        ->toBe(['finance@customer.test']);
 });
 
 it('blocks replies from members without send permission', function () {

--- a/tests/Feature/InboxTest.php
+++ b/tests/Feature/InboxTest.php
@@ -141,6 +141,28 @@ it('keeps read state personal while sharing assignment and workflow state', func
         ->and($thread->events()->where('type', 'workflow_updated')->exists())->toBeTrue();
 });
 
+it('bulk triages only project-scoped conversations and records activity', function () {
+    [$user, $project, $source] = inboxFixture();
+    Queue::fake();
+    receiveThreadedEmail($this, $source, 'Bulk one', 'bulk-1@customer.test');
+    receiveThreadedEmail($this, $source, 'Bulk two', 'bulk-2@customer.test');
+    $threads = Thread::query()->orderBy('id')->get();
+
+    $this->actingAs($user)
+        ->post("/projects/{$project->slug}/inbox/bulk", [
+            'thread_ids' => $threads->pluck('public_id')->all(),
+            'action' => 'close',
+        ])
+        ->assertRedirect();
+
+    expect(Thread::query()->where('status', 'closed')->count())->toBe(2)
+        ->and($threads->first()->events()->where('type', 'bulk_close')->exists())->toBeTrue();
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/inbox?mailbox=closed")
+        ->assertInertia(fn ($page) => $page->has('threads', 2));
+});
+
 it('filters mailboxes and blocks cross-project thread access', function () {
     [$user, $project, $source] = inboxFixture();
 

--- a/tests/Feature/InboxTest.php
+++ b/tests/Feature/InboxTest.php
@@ -74,7 +74,7 @@ it('renders the inbox with threads, counts, and interleaved messages', function 
             ->where('addresses.0.address', 'support@example.com'));
 });
 
-it('counts and filters addresses by distinct conversations in the current mailbox', function () {
+it('keeps address views stable and counts distinct conversations', function () {
     [$user, $project, $source] = inboxFixture();
 
     Queue::fake();
@@ -90,20 +90,23 @@ it('counts and filters addresses by distinct conversations in the current mailbo
     $archivedThread->forceFill(['archived_at' => now()])->save();
 
     $this->actingAs($user)
-        ->get("/projects/{$project->slug}/inbox?mailbox=inbox&address=support%40example.com")
+        ->get("/projects/{$project->slug}/inbox?mailbox=inbox")
         ->assertInertia(fn ($page) => $page
-            ->has('addresses', 1)
+            ->has('addresses', 2)
             ->where('addresses.0.address', 'support@example.com')
             ->where('addresses.0.count', 2)
+            ->where('addresses.1.address', 'archive@example.com')
+            ->where('addresses.1.count', 1)
             ->has('threads', 2));
 
     $this->actingAs($user)
-        ->get("/projects/{$project->slug}/inbox?mailbox=archived")
+        ->get("/projects/{$project->slug}/inbox?mailbox=all&address=archive%40example.com")
         ->assertInertia(fn ($page) => $page
-            ->has('addresses', 1)
-            ->where('addresses.0.address', 'archive@example.com')
-            ->where('addresses.0.count', 1)
-            ->has('threads', 1));
+            ->where('mailbox', 'all')
+            ->where('address', 'archive@example.com')
+            ->has('addresses', 2)
+            ->has('threads', 1)
+            ->where('threads.0.subject', 'Archived address'));
 });
 
 it('marks a thread read when opened explicitly', function () {

--- a/tests/Feature/InboxTest.php
+++ b/tests/Feature/InboxTest.php
@@ -3,6 +3,7 @@
 use App\Models\Project;
 use App\Models\Source;
 use App\Models\Thread;
+use App\Models\ThreadUserState;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Support\Facades\Queue;
@@ -87,7 +88,7 @@ it('marks a thread read when opened explicitly', function () {
         ->get("/projects/{$project->slug}/inbox?thread={$thread->public_id}")
         ->assertInertia(fn ($page) => $page->where('selectedThread.unread', false));
 
-    expect($thread->fresh()->read_at)->not->toBeNull();
+    expect(ThreadUserState::query()->whereBelongsTo($thread)->whereBelongsTo($user)->value('read_at'))->not->toBeNull();
 });
 
 it('archives, restores, and toggles unread through thread actions', function () {
@@ -105,10 +106,39 @@ it('archives, restores, and toggles unread through thread actions', function () 
     expect($thread->fresh()->archived_at)->toBeNull();
 
     $this->actingAs($user)->post("/projects/{$project->slug}/threads/{$thread->public_id}/read");
-    expect($thread->fresh()->read_at)->not->toBeNull();
+    expect(ThreadUserState::query()->whereBelongsTo($thread)->whereBelongsTo($user)->value('read_at'))->not->toBeNull();
 
     $this->actingAs($user)->post("/projects/{$project->slug}/threads/{$thread->public_id}/unread");
-    expect($thread->fresh()->read_at)->toBeNull();
+    expect(ThreadUserState::query()->whereBelongsTo($thread)->whereBelongsTo($user)->value('read_at'))->toBeNull();
+});
+
+it('keeps read state personal while sharing assignment and workflow state', function () {
+    [$owner, $project, $source] = inboxFixture();
+    $member = User::factory()->create();
+    $project->workspace->users()->attach($member, ['role' => 'member']);
+    Queue::fake();
+    receiveThreadedEmail($this, $source, 'Team work', 'team-work@customer.test');
+    $thread = Thread::query()->firstOrFail();
+
+    $this->actingAs($owner)->get("/projects/{$project->slug}/inbox?thread={$thread->public_id}")->assertSuccessful();
+
+    $this->actingAs($member)
+        ->get("/projects/{$project->slug}/inbox?mailbox=unread")
+        ->assertInertia(fn ($page) => $page->has('threads', 1));
+
+    $this->actingAs($owner)
+        ->patch("/projects/{$project->slug}/threads/{$thread->public_id}/workflow", [
+            'status' => 'pending',
+            'priority' => 'high',
+            'assigned_to_user_id' => $member->id,
+        ])
+        ->assertRedirect();
+
+    expect($thread->fresh())
+        ->status->toBe('pending')
+        ->priority->toBe('high')
+        ->assigned_to_user_id->toBe($member->id)
+        ->and($thread->events()->where('type', 'workflow_updated')->exists())->toBeTrue();
 });
 
 it('filters mailboxes and blocks cross-project thread access', function () {

--- a/tests/Feature/InboxTest.php
+++ b/tests/Feature/InboxTest.php
@@ -28,11 +28,11 @@ function inboxFixture(): array
     return [$user, $project, $source];
 }
 
-function receiveThreadedEmail($test, Source $source, string $subject, string $messageId, string $from = 'maya@customer.test'): void
+function receiveThreadedEmail($test, Source $source, string $subject, string $messageId, string $from = 'maya@customer.test', string $to = 'support@example.com'): void
 {
     $mime = implode("\r\n", [
         "From: {$from}",
-        'To: support@example.com',
+        "To: {$to}",
         "Subject: {$subject}",
         "Message-ID: <{$messageId}>",
         'Content-Type: text/plain; charset=utf-8',
@@ -43,7 +43,7 @@ function receiveThreadedEmail($test, Source $source, string $subject, string $me
 
     $test->postJson("/api/webhooks/inbound/cloudflare/{$source->webhook_token}", [
         'from' => $from,
-        'to' => 'support@example.com',
+        'to' => $to,
         'raw' => base64_encode($mime),
     ])->assertStatus(202);
 }
@@ -72,6 +72,38 @@ it('renders the inbox with threads, counts, and interleaved messages', function 
             ->where('projects.0.is_current', true)
             ->where('projects.0.href', '/projects/helpdesk/inbox')
             ->where('addresses.0.address', 'support@example.com'));
+});
+
+it('counts and filters addresses by distinct conversations in the current mailbox', function () {
+    [$user, $project, $source] = inboxFixture();
+
+    Queue::fake();
+
+    receiveThreadedEmail($this, $source, 'Repeated conversation', 'address-1@customer.test');
+    receiveThreadedEmail($this, $source, 'Repeated conversation', 'address-2@customer.test');
+    receiveThreadedEmail($this, $source, 'Another conversation', 'address-3@customer.test');
+    receiveThreadedEmail($this, $source, 'Archived address', 'address-4@customer.test', to: 'archive@example.com');
+
+    $archivedThread = Thread::query()
+        ->whereHas('inboundEmails', fn ($query) => $query->where('to_email', 'archive@example.com'))
+        ->firstOrFail();
+    $archivedThread->forceFill(['archived_at' => now()])->save();
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/inbox?mailbox=inbox&address=support%40example.com")
+        ->assertInertia(fn ($page) => $page
+            ->has('addresses', 1)
+            ->where('addresses.0.address', 'support@example.com')
+            ->where('addresses.0.count', 2)
+            ->has('threads', 2));
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/inbox?mailbox=archived")
+        ->assertInertia(fn ($page) => $page
+            ->has('addresses', 1)
+            ->where('addresses.0.address', 'archive@example.com')
+            ->where('addresses.0.count', 1)
+            ->has('threads', 1));
 });
 
 it('marks a thread read when opened explicitly', function () {


### PR DESCRIPTION
## Summary
- separate personal unread state from shared team workflow state
- add assignment, Open/Pending/Closed, priority, tags, active-viewer awareness, and audit history
- add Mine/Unassigned views, bulk triage, pagination, full-content search, and responsive mailbox filters
- improve compose/reply with sender selection, multiple To recipients, CC/BCC, reply-all, templates, attachments, failure details, and retries
- add opt-in new-mail notifications, contextual empty states, and remote-tracking protection

## Validation
- php artisan test --compact (214 tests, 1,416 assertions)
- npm run types:check
- focused ESLint and Prettier checks
- npm run build
- live Inbox browser regression review including compose, bulk mode, audit history, and tagging

This is the follow-up to merged PRs #4, #5, and #6. It does not deploy automatically.