### PR TITLE
Fix Laravel Cloud PostgreSQL migration order

### DIFF
--- a/database/migrations/2026_07_11_001656_create_threads_table.php
+++ b/database/migrations/2026_07_11_001656_create_threads_table.php
@@ -8,6 +8,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (Schema::hasTable('threads')) {
+            return;
+        }
+
         Schema::create('threads', function (Blueprint $table) {
             $table->id();
             $table->string('public_id')->unique();


### PR DESCRIPTION
## Root cause
Laravel Cloud runs PostgreSQL. Two thread migrations shared the same timestamp, so alphabetical ordering ran the add-thread-ID migration before the create-threads-table migration. PostgreSQL rejected the foreign keys because the referenced table did not exist, causing the deploy migration command to fail.

## Fix
- move thread table creation one migration slot earlier
- guard table creation for local databases that already recorded the old filename

## Validation
- clean testing migration confirms the thread table is created before its foreign keys
- focused Inbox, reply, and threading suite: 16 tests, 164 assertions