### PR TITLE
Fix suppression lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ ses:SendEmail
 ses:CreateEmailIdentity
 ses:GetEmailIdentity
 ses:GetAccount
+ses:DeleteSuppressedDestination
 ```
 
 Recommended setup:

--- a/app/Exceptions/SuppressionProviderUnavailableException.php
+++ b/app/Exceptions/SuppressionProviderUnavailableException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Exceptions;
+
+class SuppressionProviderUnavailableException extends SuppressionRemovalException {}

--- a/app/Exceptions/SuppressionRemovalException.php
+++ b/app/Exceptions/SuppressionRemovalException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class SuppressionRemovalException extends Exception {}

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -536,6 +536,7 @@ class ActivityController extends Controller
     private function suppressions(Project $project): array
     {
         return $project->suppressions()
+            ->with('source:id,provider')
             ->latest()
             ->limit(100)
             ->get()
@@ -544,6 +545,7 @@ class ActivityController extends Controller
                 'email' => $suppression->email,
                 'reason' => $suppression->reason,
                 'source' => $suppression->event_type,
+                'provider' => $suppression->source?->provider?->value,
                 'added' => $suppression->created_at->diffForHumans(short: true),
                 'expires' => $suppression->expires_at?->toDateString() ?? 'Never',
                 'active' => $suppression->expires_at === null || $suppression->expires_at->isFuture(),

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -84,6 +84,7 @@ class ActivityController extends Controller
                 'can_manage_members' => $project->workspace->canManageMembers($user),
                 'can_manage_api_keys' => $project->workspace->canManageApiKeys($user),
                 'can_manage_domains' => $project->workspace->canManageDomains($user),
+                'can_manage_suppressions' => $project->workspace->canManageSuppressions($user),
                 'can_send' => $project->workspace->canSendEmail($user),
             ],
             'workspaceMembers' => $this->workspaceMembers($project),

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -154,6 +154,7 @@ class ActivityController extends Controller
             'webhookStats' => $this->webhookStats($project),
             'webhookDeliveries' => $this->webhookDeliveries($project),
             'suppressions' => $this->suppressions($project),
+            'suppressionStats' => $this->suppressionStats($project),
             'newWebhookEndpoint' => session('newWebhookEndpoint'),
             'sesWebhookUrl' => $source && $source->provider === SourceProvider::Ses
                 ? route('webhooks.ses', $source->webhook_token)
@@ -168,7 +169,7 @@ class ActivityController extends Controller
                 'sent' => $project->emails()->whereIn('status', ['sent', 'delivered', 'opened', 'clicked'])->count(),
                 'bounces' => $project->emails()->where('status', 'bounced')->count(),
                 'complaints' => $project->emails()->where('status', 'complained')->count(),
-                'suppressions' => $project->suppressions()->count(),
+                'suppressions' => $project->suppressions()->active()->count(),
             ],
             'inboxUnread' => $this->activeInboxThreads($project)->whereNull('read_at')->count(),
             'recentThreads' => $section === 'activity'
@@ -544,8 +545,25 @@ class ActivityController extends Controller
                 'source' => $suppression->event_type,
                 'added' => $suppression->created_at->diffForHumans(short: true),
                 'expires' => $suppression->expires_at?->toDateString() ?? 'Never',
+                'active' => $suppression->expires_at === null || $suppression->expires_at->isFuture(),
+                'expires_at' => $suppression->expires_at?->toIso8601String(),
             ])
             ->all();
+    }
+
+    /**
+     * @return array{active: int, hard_bounce: int, complaint: int, expired: int}
+     */
+    private function suppressionStats(Project $project): array
+    {
+        $suppressions = $project->suppressions();
+
+        return [
+            'active' => (clone $suppressions)->active()->count(),
+            'hard_bounce' => (clone $suppressions)->active()->where('reason', 'hard_bounce')->count(),
+            'complaint' => (clone $suppressions)->active()->where('reason', 'complaint')->count(),
+            'expired' => (clone $suppressions)->whereNotNull('expires_at')->where('expires_at', '<=', now())->count(),
+        ];
     }
 
     /**

--- a/app/Http/Controllers/ActivityExportController.php
+++ b/app/Http/Controllers/ActivityExportController.php
@@ -72,7 +72,7 @@ class ActivityExportController extends Controller
 
     private function formulaSafe(string $value): string
     {
-        if (in_array($value[0] ?? '', ['=', '+', '-', '@'], true)) {
+        if (preg_match('/\A[\x00-\x20]*[=+\-@]/', $value) === 1) {
             return "'{$value}";
         }
 

--- a/app/Http/Controllers/ActivityExportController.php
+++ b/app/Http/Controllers/ActivityExportController.php
@@ -19,6 +19,11 @@ class ActivityExportController extends Controller
             is_string($projectSlug) ? $projectSlug : null,
         );
         $section = (string) $request->query('section', 'activity');
+
+        if ($section === 'suppressions') {
+            return $this->suppressionExport($project);
+        }
+
         $emails = $this->activityEmailsQuery($project, $request, $section)->get();
 
         return response()->streamDownload(function () use ($emails) {
@@ -40,6 +45,38 @@ class ActivityExportController extends Controller
 
             fclose($handle);
         }, 'larasend-activity.csv', ['Content-Type' => 'text/csv']);
+    }
+
+    private function suppressionExport(Project $project): StreamedResponse
+    {
+        $suppressions = $project->suppressions()->latest()->get();
+
+        return response()->streamDownload(function () use ($suppressions): void {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, ['Recipient', 'Reason', 'Source', 'Added at', 'Expires at', 'Status']);
+
+            foreach ($suppressions as $suppression) {
+                fputcsv($handle, [
+                    $this->formulaSafe($suppression->email),
+                    $this->formulaSafe($suppression->reason),
+                    $this->formulaSafe($suppression->event_type),
+                    $suppression->created_at->toIso8601String(),
+                    $suppression->expires_at?->toIso8601String() ?? '',
+                    $suppression->expires_at === null || $suppression->expires_at->isFuture() ? 'Active' : 'Expired',
+                ]);
+            }
+
+            fclose($handle);
+        }, 'larasend-suppressions.csv', ['Content-Type' => 'text/csv']);
+    }
+
+    private function formulaSafe(string $value): string
+    {
+        if (in_array($value[0] ?? '', ['=', '+', '-', '@'], true)) {
+            return "'{$value}";
+        }
+
+        return $value;
     }
 
     private function activityEmailsQuery(Project $project, Request $request, string $section): HasMany

--- a/app/Http/Controllers/Api/SuppressionController.php
+++ b/app/Http/Controllers/Api/SuppressionController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Exceptions\SuppressionRemovalException;
+use App\Http\Controllers\Controller;
+use App\Models\Project;
+use App\Models\Suppression;
+use App\Services\SuppressionRemovalService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class SuppressionController extends Controller
+{
+    public function destroy(
+        Request $request,
+        Suppression $suppression,
+        SuppressionRemovalService $removalService,
+    ): Response|JsonResponse {
+        /** @var Project $project */
+        $project = $request->attributes->get('larasend_project');
+
+        abort_unless($suppression->project_id === $project->id, 404);
+
+        try {
+            $removalService->remove($suppression);
+        } catch (SuppressionRemovalException $exception) {
+            return response()->json(['message' => $exception->getMessage()], 422);
+        }
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/SuppressionController.php
+++ b/app/Http/Controllers/Api/SuppressionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Exceptions\SuppressionProviderUnavailableException;
 use App\Exceptions\SuppressionRemovalException;
 use App\Http\Controllers\Controller;
 use App\Models\Project;
@@ -25,8 +26,10 @@ class SuppressionController extends Controller
 
         try {
             $removalService->remove($suppression);
+        } catch (SuppressionProviderUnavailableException $exception) {
+            return response()->json(['message' => $exception->getMessage()], 503);
         } catch (SuppressionRemovalException $exception) {
-            return response()->json(['message' => $exception->getMessage()], 422);
+            return response()->json(['message' => $exception->getMessage()], 409);
         }
 
         return response()->noContent();

--- a/app/Http/Controllers/DashboardActionController.php
+++ b/app/Http/Controllers/DashboardActionController.php
@@ -292,7 +292,7 @@ class DashboardActionController extends Controller
             $project,
             $apiKey->name,
             $apiKey->source,
-            $apiKey->scopes ?: ['send', 'read:activity'],
+            $apiKey->scopes,
             $apiKey->expires_at,
         );
 

--- a/app/Http/Controllers/DashboardActionController.php
+++ b/app/Http/Controllers/DashboardActionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\SourceProvider;
+use App\Exceptions\SuppressionRemovalException;
 use App\Http\Requests\DashboardSendEmailRequest;
 use App\Http\Requests\StoreApiKeyRequest;
 use App\Http\Requests\StoreDomainRequest;
@@ -15,6 +16,7 @@ use App\Models\Domain;
 use App\Models\Email;
 use App\Models\Project;
 use App\Models\Source;
+use App\Models\Suppression;
 use App\Models\User;
 use App\Models\WebhookEndpoint;
 use App\Services\DnsRecordVerifier;
@@ -22,6 +24,7 @@ use App\Services\EmailSendService;
 use App\Services\Providers\CloudflareInboundProvisioner;
 use App\Services\Providers\DomainOnboardingException;
 use App\Services\Providers\EmailProviderFactory;
+use App\Services\SuppressionRemovalService;
 use App\Support\ProjectContext;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -298,6 +301,44 @@ class DashboardActionController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => 'API key rotated. Copy the new key now.']);
 
         return $this->toProjectSection($project, 'api-keys')->with('newApiKey', $issued['plain_text']);
+    }
+
+    public function destroySuppression(
+        Suppression $suppression,
+        SuppressionRemovalService $removalService,
+    ): RedirectResponse {
+        return $this->deleteSuppression($suppression, $removalService);
+    }
+
+    public function destroyProjectSuppression(
+        string $projectSlug,
+        Suppression $suppression,
+        SuppressionRemovalService $removalService,
+    ): RedirectResponse {
+        return $this->deleteSuppression($suppression, $removalService);
+    }
+
+    private function deleteSuppression(
+        Suppression $suppression,
+        SuppressionRemovalService $removalService,
+    ): RedirectResponse {
+        $project = $this->projectFor(Auth::user());
+        $this->authorizeWorkspaceCapability($project, 'manage_suppressions');
+
+        abort_unless($suppression->project_id === $project->id, 404);
+
+        try {
+            $removalService->remove($suppression);
+        } catch (SuppressionRemovalException $exception) {
+            Inertia::flash('toast', ['type' => 'error', 'message' => $exception->getMessage()]);
+
+            return $this->toProjectSection($project, 'suppressions')
+                ->withErrors(['suppression' => $exception->getMessage()]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => 'Suppression removed.']);
+
+        return $this->toProjectSection($project, 'suppressions');
     }
 
     public function storeWebhookEndpoint(StoreWebhookEndpointRequest $request): RedirectResponse
@@ -579,6 +620,7 @@ class DashboardActionController extends Controller
             'manage_domains' => $project->workspace->canManageDomains($user),
             'manage_templates' => $project->workspace->canManageTemplates($user),
             'manage_webhooks' => $project->workspace->canManageWebhooks($user),
+            'manage_suppressions' => $project->workspace->canManageSuppressions($user),
             default => false,
         };
 

--- a/app/Http/Middleware/AuthenticateLarasendApiKey.php
+++ b/app/Http/Middleware/AuthenticateLarasendApiKey.php
@@ -34,7 +34,16 @@ class AuthenticateLarasendApiKey
             return response()->json(['message' => 'Invalid Larasend API key.'], 401);
         }
 
-        $requiredScope = $request->isMethod('post') ? 'send' : 'read:activity';
+        $requiredScope = match ($request->route()?->getName()) {
+            'api.emails.index', 'api.emails.show' => 'read:activity',
+            'api.emails.store' => 'send',
+            'api.suppressions.destroy' => 'manage:suppressions',
+            default => null,
+        };
+
+        if ($requiredScope === null) {
+            return response()->json(['message' => 'This API route has no configured Larasend API key scope.'], 403);
+        }
 
         if (! $apiKey->allows($requiredScope)) {
             return response()->json(['message' => "This Larasend API key is missing the {$requiredScope} scope."], 403);

--- a/app/Http/Requests/StoreApiKeyRequest.php
+++ b/app/Http/Requests/StoreApiKeyRequest.php
@@ -20,7 +20,7 @@ class StoreApiKeyRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'scopes' => ['sometimes', 'array', 'min:1'],
-            'scopes.*' => ['required', Rule::in(['send', 'read:activity'])],
+            'scopes.*' => ['required', Rule::in(['send', 'read:activity', 'manage:suppressions'])],
             'expires_at' => ['nullable', 'date', 'after:now'],
         ];
     }

--- a/app/Jobs/SyncCloudflareSourceSuppressions.php
+++ b/app/Jobs/SyncCloudflareSourceSuppressions.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\SourceProvider;
+use App\Models\Source;
+use App\Services\CloudflareApiClient;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Attributes\UniqueFor;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Mirrors one Cloudflare account's stable suppression snapshot into Larasend.
+ */
+#[UniqueFor(3900)]
+class SyncCloudflareSourceSuppressions implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public const SNAPSHOT_BUDGET_SECONDS = 50;
+
+    public const WORK_BUDGET_SECONDS = 70;
+
+    public int $tries = 3;
+
+    public int $timeout = 75;
+
+    public function __construct(public int $sourceId) {}
+
+    public function handle(CloudflareApiClient $cloudflare): void
+    {
+        $deadline = $this->monotonicTime() + self::WORK_BUDGET_SECONDS;
+        $source = Source::query()
+            ->whereKey($this->sourceId)
+            ->where('provider', SourceProvider::Cloudflare)
+            ->whereNotNull('cloudflare_api_token')
+            ->whereNotNull('cloudflare_account_id')
+            ->with('project')
+            ->first();
+
+        if ($source?->project === null) {
+            return;
+        }
+
+        $project = $source->project;
+        $suppressions = $cloudflare->listStableSuppressions(
+            $source,
+            min(self::SNAPSHOT_BUDGET_SECONDS, $this->remainingWorkBudget($deadline)),
+        );
+        $syncedEmails = [];
+
+        foreach ($suppressions as $suppression) {
+            $this->ensureWithinWorkBudget($deadline);
+            $email = Str::lower(trim($suppression['email']));
+
+            if ($email === '') {
+                continue;
+            }
+
+            $values = [
+                'workspace_id' => $project->workspace_id,
+                'source_id' => $source->id,
+                'email_id' => null,
+                'reason' => $this->mapReason($suppression['reason']),
+                'event_type' => 'provider_sync',
+                'expires_at' => $suppression['expires_at'] ? Carbon::parse($suppression['expires_at']) : null,
+            ];
+
+            $candidate = $project->suppressions()->firstOrCreate(
+                ['email' => $email],
+                $values,
+            );
+
+            $isOwned = DB::transaction(function () use ($project, $source, $candidate, $values): bool {
+                $existing = $project->suppressions()
+                    ->whereKey($candidate->id)
+                    ->lockForUpdate()
+                    ->firstOrFail();
+
+                $isCloudflareOwned = $existing->source_id === $source->id
+                    && $existing->event_type === 'provider_sync';
+                $isActive = $existing->expires_at === null
+                    || $existing->expires_at->isFuture();
+
+                if (! $isCloudflareOwned && $isActive) {
+                    return false;
+                }
+
+                $existing->update($values);
+
+                return true;
+            });
+
+            if ($isOwned) {
+                $syncedEmails[] = $email;
+            }
+        }
+
+        $this->ensureWithinWorkBudget($deadline);
+        $providerSyncSuppressions = $project->suppressions()
+            ->where('source_id', $source->id)
+            ->where('event_type', 'provider_sync');
+
+        if ($syncedEmails === []) {
+            $providerSyncSuppressions->delete();
+
+            return;
+        }
+
+        $providerSyncSuppressions->whereNotIn('email', $syncedEmails)->delete();
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [5, 30, 120];
+    }
+
+    public function uniqueId(): string
+    {
+        return (string) $this->sourceId;
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        if ($exception !== null) {
+            report($exception);
+        }
+    }
+
+    private function ensureWithinWorkBudget(float $deadline): void
+    {
+        $this->remainingWorkBudget($deadline);
+    }
+
+    private function remainingWorkBudget(float $deadline): float
+    {
+        $remaining = $deadline - $this->monotonicTime();
+
+        if ($remaining <= 0) {
+            throw new RuntimeException('Cloudflare suppression source sync exceeded its work budget. No destructive changes were made.');
+        }
+
+        return $remaining;
+    }
+
+    protected function monotonicTime(): float
+    {
+        return hrtime(true) / 1_000_000_000;
+    }
+
+    private function mapReason(string $reason): string
+    {
+        return match (true) {
+            str_contains($reason, 'complaint') || str_contains($reason, 'spam') => 'complaint',
+            default => 'hard_bounce',
+        };
+    }
+}

--- a/app/Jobs/SyncCloudflareSourceSuppressions.php
+++ b/app/Jobs/SyncCloudflareSourceSuppressions.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Enums\SourceProvider;
 use App\Models\Source;
+use App\Models\Suppression;
 use App\Services\CloudflareApiClient;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -11,7 +12,6 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Attributes\UniqueFor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use RuntimeException;
 use Throwable;
 
@@ -57,7 +57,7 @@ class SyncCloudflareSourceSuppressions implements ShouldBeUnique, ShouldQueue
 
         foreach ($suppressions as $suppression) {
             $this->ensureWithinWorkBudget($deadline);
-            $email = Str::lower(trim($suppression['email']));
+            $email = Suppression::normalizeEmail($suppression['email']);
 
             if ($email === '') {
                 continue;

--- a/app/Jobs/SyncCloudflareSourceSuppressions.php
+++ b/app/Jobs/SyncCloudflareSourceSuppressions.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Enums\SourceProvider;
+use App\Models\Project;
 use App\Models\Source;
 use App\Models\Suppression;
 use App\Services\CloudflareApiClient;
@@ -72,10 +73,7 @@ class SyncCloudflareSourceSuppressions implements ShouldBeUnique, ShouldQueue
                 'expires_at' => $suppression['expires_at'] ? Carbon::parse($suppression['expires_at']) : null,
             ];
 
-            $candidate = $project->suppressions()->firstOrCreate(
-                ['email' => $email],
-                $values,
-            );
+            $candidate = $this->suppressionForEmail($project, $email, $values);
 
             $isOwned = DB::transaction(function () use ($project, $source, $candidate, $values): bool {
                 $existing = $project->suppressions()
@@ -113,7 +111,7 @@ class SyncCloudflareSourceSuppressions implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $providerSyncSuppressions->whereNotIn('email', $syncedEmails)->delete();
+        $providerSyncSuppressions->whereNormalizedEmailNotIn($syncedEmails)->delete();
     }
 
     /**
@@ -155,6 +153,16 @@ class SyncCloudflareSourceSuppressions implements ShouldBeUnique, ShouldQueue
     protected function monotonicTime(): float
     {
         return hrtime(true) / 1_000_000_000;
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    private function suppressionForEmail(Project $project, string $email, array $values): Suppression
+    {
+        return $project->suppressions()
+            ->whereNormalizedEmail($email)
+            ->firstOrCreate([], ['email' => $email, ...$values]);
     }
 
     private function mapReason(string $reason): string

--- a/app/Jobs/SyncCloudflareSuppressions.php
+++ b/app/Jobs/SyncCloudflareSuppressions.php
@@ -4,102 +4,57 @@ namespace App\Jobs;
 
 use App\Enums\SourceProvider;
 use App\Models\Source;
-use App\Services\CloudflareApiClient;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Attributes\UniqueFor;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Throwable;
 
 /**
- * Cloudflare has no delivery-event webhooks; suppressions accumulate on the
- * account-level list instead. This pull-only sync mirrors that list into
- * Larasend so suppressed recipients are blocked before a send is attempted.
+ * Dispatches a bounded page of independent Cloudflare suppression syncs.
  */
 #[UniqueFor(3900)]
 class SyncCloudflareSuppressions implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
-    public int $timeout = 75;
+    public const BATCH_SIZE = 25;
 
-    public function handle(CloudflareApiClient $cloudflare): void
+    public int $timeout = 15;
+
+    public function __construct(public ?int $afterSourceId = null) {}
+
+    public function handle(): void
     {
-        Source::query()
+        $sourceIds = Source::query()
             ->where('provider', SourceProvider::Cloudflare)
             ->whereNotNull('cloudflare_api_token')
             ->whereNotNull('cloudflare_account_id')
-            ->with('project')
-            ->each(function (Source $source) use ($cloudflare): void {
-                try {
-                    $this->syncSource($cloudflare, $source);
-                } catch (Throwable $exception) {
-                    // One bad token must not abort the run for other sources.
-                    report($exception);
-                }
-            });
+            ->when($this->afterSourceId !== null, fn ($query) => $query->where('id', '>', $this->afterSourceId))
+            ->orderBy('id')
+            ->limit(self::BATCH_SIZE + 1)
+            ->pluck('id');
+
+        $sourceIds
+            ->take(self::BATCH_SIZE)
+            ->each(fn (int $sourceId) => SyncCloudflareSourceSuppressions::dispatch($sourceId));
+
+        if ($sourceIds->count() > self::BATCH_SIZE) {
+            self::dispatch((int) $sourceIds[self::BATCH_SIZE - 1]);
+        }
     }
 
-    private function syncSource(CloudflareApiClient $cloudflare, Source $source): void
+    public function uniqueId(): string
     {
-        $project = $source->project;
-
-        if (! $project) {
-            return;
-        }
-
-        $suppressions = $cloudflare->listStableSuppressions($source);
-        $syncedEmails = [];
-
-        foreach ($suppressions as $suppression) {
-            $email = Str::lower(trim($suppression['email']));
-
-            if ($email === '') {
-                continue;
-            }
-
-            $values = [
-                'workspace_id' => $project->workspace_id,
-                'source_id' => $source->id,
-                'email_id' => null,
-                'reason' => $this->mapReason($suppression['reason']),
-                'event_type' => 'provider_sync',
-                'expires_at' => $suppression['expires_at'] ? Carbon::parse($suppression['expires_at']) : null,
-            ];
-
-            $existing = $project->suppressions()->firstOrCreate(
-                ['email' => $email],
-                $values,
-            );
-
-            if ($existing->source_id !== $source->id || $existing->event_type !== 'provider_sync') {
-                continue;
-            }
-
-            $existing->update($values);
-            $syncedEmails[] = $email;
-        }
-
-        $providerSyncSuppressions = $project->suppressions()
-            ->where('source_id', $source->id)
-            ->where('event_type', 'provider_sync');
-
-        if ($syncedEmails === []) {
-            $providerSyncSuppressions->delete();
-
-            return;
-        }
-
-        $providerSyncSuppressions->whereNotIn('email', $syncedEmails)->delete();
+        return $this->afterSourceId === null
+            ? 'cloudflare-suppressions:root'
+            : "cloudflare-suppressions:after:{$this->afterSourceId}";
     }
 
-    private function mapReason(string $reason): string
+    public function failed(?Throwable $exception): void
     {
-        return match (true) {
-            str_contains($reason, 'complaint') || str_contains($reason, 'spam') => 'complaint',
-            default => 'hard_bounce',
-        };
+        if ($exception !== null) {
+            report($exception);
+        }
     }
 }

--- a/app/Jobs/SyncCloudflareSuppressions.php
+++ b/app/Jobs/SyncCloudflareSuppressions.php
@@ -48,12 +48,17 @@ class SyncCloudflareSuppressions implements ShouldQueue
             return;
         }
 
-        foreach ($cloudflare->listSuppressions($source) as $suppression) {
+        $suppressions = $cloudflare->listSuppressions($source);
+        $syncedEmails = [];
+
+        foreach ($suppressions as $suppression) {
             $email = Str::lower(trim($suppression['email']));
 
             if ($email === '') {
                 continue;
             }
+
+            $syncedEmails[] = $email;
 
             Suppression::query()->updateOrCreate(
                 [
@@ -70,6 +75,18 @@ class SyncCloudflareSuppressions implements ShouldQueue
                 ],
             );
         }
+
+        $providerSyncSuppressions = $project->suppressions()
+            ->where('source_id', $source->id)
+            ->where('event_type', 'provider_sync');
+
+        if ($syncedEmails === []) {
+            $providerSyncSuppressions->delete();
+
+            return;
+        }
+
+        $providerSyncSuppressions->whereNotIn('email', $syncedEmails)->delete();
     }
 
     private function mapReason(string $reason): string

--- a/app/Jobs/SyncCloudflareSuppressions.php
+++ b/app/Jobs/SyncCloudflareSuppressions.php
@@ -4,10 +4,11 @@ namespace App\Jobs;
 
 use App\Enums\SourceProvider;
 use App\Models\Source;
-use App\Models\Suppression;
 use App\Services\CloudflareApiClient;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Attributes\UniqueFor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Throwable;
@@ -17,11 +18,12 @@ use Throwable;
  * account-level list instead. This pull-only sync mirrors that list into
  * Larasend so suppressed recipients are blocked before a send is attempted.
  */
-class SyncCloudflareSuppressions implements ShouldQueue
+#[UniqueFor(3900)]
+class SyncCloudflareSuppressions implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
-    public int $timeout = 120;
+    public int $timeout = 75;
 
     public function handle(CloudflareApiClient $cloudflare): void
     {
@@ -48,7 +50,7 @@ class SyncCloudflareSuppressions implements ShouldQueue
             return;
         }
 
-        $suppressions = $cloudflare->listSuppressions($source);
+        $suppressions = $cloudflare->listStableSuppressions($source);
         $syncedEmails = [];
 
         foreach ($suppressions as $suppression) {
@@ -58,22 +60,26 @@ class SyncCloudflareSuppressions implements ShouldQueue
                 continue;
             }
 
-            $syncedEmails[] = $email;
+            $values = [
+                'workspace_id' => $project->workspace_id,
+                'source_id' => $source->id,
+                'email_id' => null,
+                'reason' => $this->mapReason($suppression['reason']),
+                'event_type' => 'provider_sync',
+                'expires_at' => $suppression['expires_at'] ? Carbon::parse($suppression['expires_at']) : null,
+            ];
 
-            Suppression::query()->updateOrCreate(
-                [
-                    'project_id' => $project->id,
-                    'email' => $email,
-                ],
-                [
-                    'workspace_id' => $project->workspace_id,
-                    'source_id' => $source->id,
-                    'email_id' => null,
-                    'reason' => $this->mapReason($suppression['reason']),
-                    'event_type' => 'provider_sync',
-                    'expires_at' => $suppression['expires_at'] ? Carbon::parse($suppression['expires_at']) : null,
-                ],
+            $existing = $project->suppressions()->firstOrCreate(
+                ['email' => $email],
+                $values,
             );
+
+            if ($existing->source_id !== $source->id || $existing->event_type !== 'provider_sync') {
+                continue;
+            }
+
+            $existing->update($values);
+            $syncedEmails[] = $email;
         }
 
         $providerSyncSuppressions = $project->suppressions()

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -34,9 +34,10 @@ class ApiKey extends Model
     }
 
     /**
+     * @param  array<int, string>|null  $scopes
      * @return array{plain_text: string, api_key: self}
      */
-    public static function issue(Project $project, string $name, ?Source $source = null, array $scopes = ['send', 'read:activity'], ?\DateTimeInterface $expiresAt = null): array
+    public static function issue(Project $project, string $name, ?Source $source = null, ?array $scopes = ['send', 'read:activity'], ?\DateTimeInterface $expiresAt = null): array
     {
         $plainText = 'ls_'.Str::random(48);
 
@@ -48,7 +49,7 @@ class ApiKey extends Model
                 'name' => $name,
                 'prefix' => Str::substr($plainText, 0, 12),
                 'key_hash' => hash('sha256', $plainText),
-                'scopes' => array_values(array_unique($scopes)),
+                'scopes' => $scopes === null ? null : array_values(array_unique($scopes)),
                 'expires_at' => $expiresAt,
             ]),
         ];

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -58,9 +58,11 @@ class ApiKey extends Model
     {
         // Keys created before scopes existed have a null column and keep full access.
         // A present-but-empty array is an explicit grant of no scopes, so it denies everything.
-        $scopes = $this->scopes ?? ['send', 'read:activity'];
+        if ($this->scopes === null) {
+            return true;
+        }
 
-        return in_array($scope, $scopes, true);
+        return in_array($scope, $this->scopes, true);
     }
 
     public function project(): BelongsTo

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
 
 class Suppression extends Model
 {
@@ -27,6 +29,13 @@ class Suppression extends Model
         return [
             'expires_at' => 'datetime',
         ];
+    }
+
+    protected function email(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $email): string => Str::lower(trim($email)),
+        );
     }
 
     /**

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -53,6 +53,32 @@ class Suppression extends Model
     /**
      * @param  Builder<Suppression>  $query
      */
+    public function scopeWhereNormalizedEmail(Builder $query, string $email): void
+    {
+        $query->where($this->normalizedEmailColumn(), self::normalizeEmail($email));
+    }
+
+    /**
+     * @param  Builder<Suppression>  $query
+     * @param  iterable<int, string>  $emails
+     */
+    public function scopeWhereNormalizedEmailIn(Builder $query, iterable $emails): void
+    {
+        $query->whereIn($this->normalizedEmailColumn(), $this->normalizeEmails($emails));
+    }
+
+    /**
+     * @param  Builder<Suppression>  $query
+     * @param  iterable<int, string>  $emails
+     */
+    public function scopeWhereNormalizedEmailNotIn(Builder $query, iterable $emails): void
+    {
+        $query->whereNotIn($this->normalizedEmailColumn(), $this->normalizeEmails($emails));
+    }
+
+    /**
+     * @param  Builder<Suppression>  $query
+     */
     public function scopeActive(Builder $query): void
     {
         $query->where(function (Builder $query): void {
@@ -79,5 +105,25 @@ class Suppression extends Model
     public function emailMessage(): BelongsTo
     {
         return $this->belongsTo(Email::class, 'email_id');
+    }
+
+    private function normalizedEmailColumn(): string
+    {
+        return in_array($this->getConnection()->getDriverName(), ['mysql', 'mariadb', 'sqlsrv'], true)
+            ? 'email_normalized'
+            : 'email';
+    }
+
+    /**
+     * @param  iterable<int, string>  $emails
+     * @return array<int, string>
+     */
+    private function normalizeEmails(iterable $emails): array
+    {
+        return collect($emails)
+            ->map(fn (string $email): string => self::normalizeEmail($email))
+            ->uniqueStrict()
+            ->values()
+            ->all();
     }
 }

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -26,6 +27,17 @@ class Suppression extends Model
         return [
             'expires_at' => 'datetime',
         ];
+    }
+
+    /**
+     * @param  Builder<Suppression>  $query
+     */
+    public function scopeActive(Builder $query): void
+    {
+        $query->where(function (Builder $query): void {
+            $query->whereNull('expires_at')
+                ->orWhere('expires_at', '>', now());
+        });
     }
 
     public function workspace(): BelongsTo

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -7,11 +7,14 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Str;
 
 class Suppression extends Model
 {
     use HasFactory;
+
+    private const ASCII_LOWERCASE = 'abcdefghijklmnopqrstuvwxyz';
+
+    private const ASCII_UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
     protected $fillable = [
         'workspace_id',
@@ -34,7 +37,16 @@ class Suppression extends Model
     protected function email(): Attribute
     {
         return Attribute::make(
-            set: fn (string $email): string => Str::lower(trim($email)),
+            set: fn (string $email): string => self::normalizeEmail($email),
+        );
+    }
+
+    public static function normalizeEmail(string $email): string
+    {
+        return strtr(
+            trim($email, ' '),
+            self::ASCII_UPPERCASE,
+            self::ASCII_LOWERCASE,
         );
     }
 

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -16,8 +16,8 @@ class Workspace extends Model
      * @var array<string, array<int, string>>
      */
     public const ROLE_CAPABILITIES = [
-        'owner' => ['send', 'manage_api_keys', 'manage_domains', 'manage_templates', 'manage_webhooks', 'manage_members'],
-        'member' => ['send', 'manage_api_keys', 'manage_domains', 'manage_templates', 'manage_webhooks'],
+        'owner' => ['send', 'manage_api_keys', 'manage_domains', 'manage_templates', 'manage_webhooks', 'manage_suppressions', 'manage_members'],
+        'member' => ['send', 'manage_api_keys', 'manage_domains', 'manage_templates', 'manage_webhooks', 'manage_suppressions'],
         'sender' => ['send'],
         'api_keys' => ['manage_api_keys'],
         'domains' => ['manage_domains'],
@@ -101,6 +101,11 @@ class Workspace extends Model
     public function canManageWebhooks(User $user): bool
     {
         return $this->roleAllows($user, 'manage_webhooks');
+    }
+
+    public function canManageSuppressions(User $user): bool
+    {
+        return $this->roleAllows($user, 'manage_suppressions');
     }
 
     private function roleAllows(User $user, string $capability): bool

--- a/app/Services/CloudflareApiClient.php
+++ b/app/Services/CloudflareApiClient.php
@@ -11,7 +11,9 @@ use RuntimeException;
 
 class CloudflareApiClient
 {
-    public const SUPPRESSION_MAX_PAGES_PER_SNAPSHOT = 100;
+    public const SUPPRESSION_MAX_DATA_PAGES = 100;
+
+    private const SUPPRESSION_PAGE_SIZE = 100;
 
     /**
      * @return array{value: int|float|null, unit: string|null}
@@ -49,14 +51,10 @@ class CloudflareApiClient
         $page = 1;
 
         do {
-            if ($page > self::SUPPRESSION_MAX_PAGES_PER_SNAPSHOT) {
-                throw new RuntimeException('Cloudflare suppression pagination exceeded its safe page limit. No destructive changes were made.');
-            }
-
             [$requestTimeout, $connectTimeout] = $this->suppressionRequestTimeouts($deadline);
             $response = $this->request($source, $requestTimeout, $connectTimeout)->get('/email/sending/suppression', [
                 'page' => $page,
-                'per_page' => 100,
+                'per_page' => self::SUPPRESSION_PAGE_SIZE,
                 'order' => 'created_at',
                 'direction' => 'asc',
             ]);
@@ -70,6 +68,10 @@ class CloudflareApiClient
                 throw new RuntimeException('Cloudflare returned an invalid suppression list response.');
             }
 
+            if ($page > self::SUPPRESSION_MAX_DATA_PAGES && $results !== []) {
+                throw new RuntimeException('Cloudflare suppression pagination exceeded its safe data page limit. No destructive changes were made.');
+            }
+
             foreach ($results as $suppression) {
                 $suppressions[] = [
                     'id' => (string) ($suppression['id'] ?? ''),
@@ -81,7 +83,8 @@ class CloudflareApiClient
             }
 
             $page++;
-        } while ($results !== []);
+        } while ($results !== []
+            && ($page <= self::SUPPRESSION_MAX_DATA_PAGES || count($results) === self::SUPPRESSION_PAGE_SIZE));
 
         return $suppressions;
     }

--- a/app/Services/CloudflareApiClient.php
+++ b/app/Services/CloudflareApiClient.php
@@ -47,7 +47,11 @@ class CloudflareApiClient
 
             $this->ensureSuccessful($response);
 
-            $results = $response->json('result') ?? [];
+            $results = $response->json('result');
+
+            if ($response->json('success') !== true || ! is_array($results) || ! array_is_list($results)) {
+                throw new RuntimeException('Cloudflare returned an invalid suppression list response.');
+            }
 
             foreach ($results as $suppression) {
                 $suppressions[] = [

--- a/app/Services/CloudflareApiClient.php
+++ b/app/Services/CloudflareApiClient.php
@@ -6,6 +6,7 @@ use App\Models\Source;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use RuntimeException;
 
 class CloudflareApiClient
@@ -67,6 +68,47 @@ class CloudflareApiClient
         } while ($results !== []);
 
         return $suppressions;
+    }
+
+    /**
+     * A bounded, stable account-level snapshot safe for destructive decisions.
+     *
+     * @return array<int, array{id: string, email: string, reason: string, created_at: string|null, expires_at: string|null}>
+     */
+    public function listStableSuppressions(Source $source): array
+    {
+        $previousSnapshot = null;
+
+        for ($attempt = 0; $attempt < 3; $attempt++) {
+            $snapshot = $this->normalizeSuppressionSnapshot($this->listSuppressions($source));
+
+            if ($previousSnapshot !== null && $snapshot === $previousSnapshot) {
+                return $snapshot;
+            }
+
+            $previousSnapshot = $snapshot;
+        }
+
+        throw new RuntimeException('Cloudflare suppression data changed during pagination. No destructive changes were made.');
+    }
+
+    /**
+     * @param  array<int, array{id: string, email: string, reason: string, created_at: string|null, expires_at: string|null}>  $suppressions
+     * @return array<int, array{id: string, email: string, reason: string, created_at: string|null, expires_at: string|null}>
+     */
+    private function normalizeSuppressionSnapshot(array $suppressions): array
+    {
+        return collect($suppressions)
+            ->map(fn (array $suppression): array => [
+                'id' => trim($suppression['id']),
+                'email' => Str::lower(trim($suppression['email'])),
+                'reason' => trim($suppression['reason']),
+                'created_at' => $suppression['created_at'],
+                'expires_at' => $suppression['expires_at'],
+            ])
+            ->sortBy(fn (array $suppression): string => json_encode($suppression, JSON_THROW_ON_ERROR))
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Services/CloudflareApiClient.php
+++ b/app/Services/CloudflareApiClient.php
@@ -11,6 +11,8 @@ use RuntimeException;
 
 class CloudflareApiClient
 {
+    public const SUPPRESSION_MAX_PAGES_PER_SNAPSHOT = 100;
+
     /**
      * @return array{value: int|float|null, unit: string|null}
      */
@@ -35,17 +37,31 @@ class CloudflareApiClient
      */
     public function listSuppressions(Source $source): array
     {
+        return $this->listSuppressionsUntil($source);
+    }
+
+    /**
+     * @return array<int, array{id: string, email: string, reason: string, created_at: string|null, expires_at: string|null}>
+     */
+    private function listSuppressionsUntil(Source $source, ?float $deadline = null): array
+    {
         $suppressions = [];
         $page = 1;
 
         do {
-            $response = $this->request($source)->get('/email/sending/suppression', [
+            if ($page > self::SUPPRESSION_MAX_PAGES_PER_SNAPSHOT) {
+                throw new RuntimeException('Cloudflare suppression pagination exceeded its safe page limit. No destructive changes were made.');
+            }
+
+            [$requestTimeout, $connectTimeout] = $this->suppressionRequestTimeouts($deadline);
+            $response = $this->request($source, $requestTimeout, $connectTimeout)->get('/email/sending/suppression', [
                 'page' => $page,
                 'per_page' => 100,
                 'order' => 'created_at',
                 'direction' => 'asc',
             ]);
 
+            $this->ensureWithinSuppressionDeadline($deadline);
             $this->ensureSuccessful($response);
 
             $results = $response->json('result');
@@ -75,12 +91,17 @@ class CloudflareApiClient
      *
      * @return array<int, array{id: string, email: string, reason: string, created_at: string|null, expires_at: string|null}>
      */
-    public function listStableSuppressions(Source $source): array
+    public function listStableSuppressions(Source $source, float $budgetSeconds): array
     {
+        if ($budgetSeconds <= 0) {
+            throw new RuntimeException('Cloudflare suppression snapshot requires a positive time budget.');
+        }
+
+        $deadline = $this->monotonicTime() + $budgetSeconds;
         $previousSnapshot = null;
 
         for ($attempt = 0; $attempt < 3; $attempt++) {
-            $snapshot = $this->normalizeSuppressionSnapshot($this->listSuppressions($source));
+            $snapshot = $this->normalizeSuppressionSnapshot($this->listSuppressionsUntil($source, $deadline));
 
             if ($previousSnapshot !== null && $snapshot === $previousSnapshot) {
                 return $snapshot;
@@ -358,12 +379,16 @@ class CloudflareApiClient
         $this->ensureSuccessful($response);
     }
 
-    private function request(Source $source): PendingRequest
-    {
+    private function request(
+        Source $source,
+        float $requestTimeout = 15,
+        float $connectTimeout = 3,
+    ): PendingRequest {
         return Http::withToken((string) $source->cloudflare_api_token)
             ->baseUrl("https://api.cloudflare.com/client/v4/accounts/{$source->cloudflare_account_id}")
             ->acceptJson()
-            ->timeout(15);
+            ->connectTimeout($connectTimeout)
+            ->timeout($requestTimeout);
     }
 
     private function rootRequest(Source $source): PendingRequest
@@ -371,7 +396,40 @@ class CloudflareApiClient
         return Http::withToken((string) $source->cloudflare_api_token)
             ->baseUrl('https://api.cloudflare.com/client/v4')
             ->acceptJson()
+            ->connectTimeout(3)
             ->timeout(15);
+    }
+
+    /**
+     * @return array{float, float}
+     */
+    private function suppressionRequestTimeouts(?float $deadline): array
+    {
+        if ($deadline === null) {
+            return [15.0, 3.0];
+        }
+
+        $remaining = $deadline - $this->monotonicTime();
+
+        if ($remaining <= 0) {
+            throw new RuntimeException('Cloudflare suppression snapshot exceeded its time budget. No destructive changes were made.');
+        }
+
+        $requestTimeout = min(15.0, $remaining);
+
+        return [$requestTimeout, min(3.0, $requestTimeout)];
+    }
+
+    private function ensureWithinSuppressionDeadline(?float $deadline): void
+    {
+        if ($deadline !== null && $this->monotonicTime() >= $deadline) {
+            throw new RuntimeException('Cloudflare suppression snapshot exceeded its time budget. No destructive changes were made.');
+        }
+    }
+
+    protected function monotonicTime(): float
+    {
+        return hrtime(true) / 1_000_000_000;
     }
 
     private function ensureSuccessful(Response $response): void

--- a/app/Services/CloudflareApiClient.php
+++ b/app/Services/CloudflareApiClient.php
@@ -3,10 +3,10 @@
 namespace App\Services;
 
 use App\Models\Source;
+use App\Models\Suppression;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
 use RuntimeException;
 
 class CloudflareApiClient
@@ -125,7 +125,7 @@ class CloudflareApiClient
         return collect($suppressions)
             ->map(fn (array $suppression): array => [
                 'id' => trim($suppression['id']),
-                'email' => Str::lower(trim($suppression['email'])),
+                'email' => Suppression::normalizeEmail($suppression['email']),
                 'reason' => trim($suppression['reason']),
                 'created_at' => $suppression['created_at'],
                 'expires_at' => $suppression['expires_at'],

--- a/app/Services/EmailSendService.php
+++ b/app/Services/EmailSendService.php
@@ -217,6 +217,7 @@ class EmailSendService
         }
 
         $suppressed = $project->suppressions()
+            ->active()
             ->whereIn('email', $recipients)
             ->pluck('email')
             ->map(fn (string $email): string => Str::lower($email))

--- a/app/Services/EmailSendService.php
+++ b/app/Services/EmailSendService.php
@@ -221,7 +221,7 @@ class EmailSendService
 
         $suppressed = $project->suppressions()
             ->active()
-            ->whereIn('email', $recipients)
+            ->whereNormalizedEmailIn($recipients)
             ->pluck('email')
             ->map(fn (string $email): string => Suppression::normalizeEmail($email))
             ->all();

--- a/app/Services/EmailSendService.php
+++ b/app/Services/EmailSendService.php
@@ -7,6 +7,7 @@ use App\Jobs\SendQueuedEmail;
 use App\Models\Email;
 use App\Models\Project;
 use App\Models\Source;
+use App\Models\Suppression;
 use App\Models\Template;
 use App\Services\Providers\EmailProviderFactory;
 use Illuminate\Support\Arr;
@@ -207,7 +208,9 @@ class EmailSendService
     {
         $recipients = collect(['to', 'cc', 'bcc'])
             ->flatMap(fn (string $type) => $payload[$type] ?? [])
-            ->map(fn (string $recipient): string => Str::lower($this->mimeBuilder->splitAddress($recipient)['email']))
+            ->map(fn (string $recipient): string => Suppression::normalizeEmail(
+                $this->mimeBuilder->splitAddress($recipient)['email'],
+            ))
             ->filter()
             ->unique()
             ->values();
@@ -220,7 +223,7 @@ class EmailSendService
             ->active()
             ->whereIn('email', $recipients)
             ->pluck('email')
-            ->map(fn (string $email): string => Str::lower($email))
+            ->map(fn (string $email): string => Suppression::normalizeEmail($email))
             ->all();
 
         if ($suppressed === []) {

--- a/app/Services/SesEventNormalizer.php
+++ b/app/Services/SesEventNormalizer.php
@@ -8,7 +8,6 @@ use App\Models\EmailEvent;
 use App\Models\Source;
 use App\Models\Suppression;
 use Carbon\CarbonImmutable;
-use Illuminate\Support\Str;
 
 class SesEventNormalizer
 {
@@ -112,7 +111,7 @@ class SesEventNormalizer
 
         $attributes = (new Suppression)->forceFill([
             'project_id' => $email->project_id,
-            'email' => Str::lower(trim($recipient)),
+            'email' => Suppression::normalizeEmail($recipient),
             'workspace_id' => $email->workspace_id,
             'source_id' => $email->source_id,
             'email_id' => $email->id,

--- a/app/Services/SesEventNormalizer.php
+++ b/app/Services/SesEventNormalizer.php
@@ -8,6 +8,7 @@ use App\Models\EmailEvent;
 use App\Models\Source;
 use App\Models\Suppression;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
 
 class SesEventNormalizer
 {
@@ -109,19 +110,21 @@ class SesEventNormalizer
             return;
         }
 
-        Suppression::query()->updateOrCreate(
-            [
-                'project_id' => $email->project_id,
-                'email' => $recipient,
-            ],
-            [
-                'workspace_id' => $email->workspace_id,
-                'source_id' => $email->source_id,
-                'email_id' => $email->id,
-                'reason' => $reason,
-                'event_type' => $eventType,
-                'expires_at' => null,
-            ],
+        $attributes = (new Suppression)->forceFill([
+            'project_id' => $email->project_id,
+            'email' => Str::lower(trim($recipient)),
+            'workspace_id' => $email->workspace_id,
+            'source_id' => $email->source_id,
+            'email_id' => $email->id,
+            'reason' => $reason,
+            'event_type' => $eventType,
+            'expires_at' => null,
+        ])->getAttributes();
+
+        Suppression::query()->upsert(
+            [$attributes],
+            ['project_id', 'email'],
+            ['workspace_id', 'source_id', 'email_id', 'reason', 'event_type', 'expires_at'],
         );
     }
 

--- a/app/Services/SesEventNormalizer.php
+++ b/app/Services/SesEventNormalizer.php
@@ -8,6 +8,7 @@ use App\Models\EmailEvent;
 use App\Models\Source;
 use App\Models\Suppression;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\ConnectionInterface;
 
 class SesEventNormalizer
 {
@@ -120,10 +121,67 @@ class SesEventNormalizer
             'expires_at' => null,
         ])->getAttributes();
 
+        $connection = (new Suppression)->getConnection();
+
+        if ($connection->getDriverName() === 'sqlsrv') {
+            $this->upsertSqlServerSuppression($connection, $attributes);
+
+            return;
+        }
+
         Suppression::query()->upsert(
             [$attributes],
             ['project_id', 'email'],
             ['workspace_id', 'source_id', 'email_id', 'reason', 'event_type', 'expires_at'],
+        );
+    }
+
+    /**
+     * SQL Server's MERGE must match the generated binary key rather than the
+     * case-insensitive raw email column. HOLDLOCK keeps the match-and-insert
+     * decision atomic with concurrent webhook deliveries.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    private function upsertSqlServerSuppression(ConnectionInterface $connection, array $attributes): void
+    {
+        $timestamp = now();
+        $values = [
+            $attributes['workspace_id'],
+            $attributes['project_id'],
+            $attributes['source_id'],
+            $attributes['email_id'],
+            $attributes['email'],
+            Suppression::normalizeEmail($attributes['email']),
+            $attributes['reason'],
+            $attributes['event_type'],
+            $attributes['expires_at'],
+            $timestamp,
+            $timestamp,
+        ];
+
+        $connection->statement(
+            <<<'SQL'
+                MERGE INTO [suppressions] WITH (HOLDLOCK) AS [target]
+                USING (VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)) AS [source]
+                    ([workspace_id], [project_id], [source_id], [email_id], [email], [email_normalized], [reason], [event_type], [expires_at], [created_at], [updated_at])
+                ON [target].[project_id] = [source].[project_id]
+                    AND [target].[email_normalized] = [source].[email_normalized] COLLATE Latin1_General_100_BIN2
+                WHEN MATCHED THEN
+                    UPDATE SET
+                        [target].[workspace_id] = [source].[workspace_id],
+                        [target].[source_id] = [source].[source_id],
+                        [target].[email_id] = [source].[email_id],
+                        [target].[email] = [source].[email],
+                        [target].[reason] = [source].[reason],
+                        [target].[event_type] = [source].[event_type],
+                        [target].[expires_at] = [source].[expires_at],
+                        [target].[updated_at] = [source].[updated_at]
+                WHEN NOT MATCHED THEN
+                    INSERT ([workspace_id], [project_id], [source_id], [email_id], [email], [reason], [event_type], [expires_at], [created_at], [updated_at])
+                    VALUES ([source].[workspace_id], [source].[project_id], [source].[source_id], [source].[email_id], [source].[email], [source].[reason], [source].[event_type], [source].[expires_at], [source].[created_at], [source].[updated_at]);
+                SQL,
+            $values,
         );
     }
 

--- a/app/Services/SesV2Client.php
+++ b/app/Services/SesV2Client.php
@@ -155,8 +155,9 @@ class SesV2Client
     {
         $credentials = $this->awsCredentials($source);
         $host = parse_url($url, PHP_URL_HOST);
-        $amzDate = gmdate('Ymd\THis\Z');
-        $date = gmdate('Ymd');
+        $timestamp = now('UTC');
+        $amzDate = $timestamp->format('Ymd\THis\Z');
+        $date = $timestamp->format('Ymd');
         $payloadHash = hash('sha256', $payload);
         $sessionToken = $credentials['session_token'] ?? null;
         $sessionHeader = filled($sessionToken) ? "x-amz-security-token:{$sessionToken}\n" : '';
@@ -166,7 +167,7 @@ class SesV2Client
             : 'content-type;host;x-amz-date';
         $canonicalRequest = implode("\n", [
             $method,
-            parse_url($url, PHP_URL_PATH),
+            $this->canonicalUri($url),
             '',
             $canonicalHeaders,
             $signedHeaders,
@@ -196,6 +197,13 @@ class SesV2Client
         }
 
         return $headers;
+    }
+
+    private function canonicalUri(string $url): string
+    {
+        $path = parse_url($url, PHP_URL_PATH) ?: '/';
+
+        return implode('/', array_map(rawurlencode(...), explode('/', $path)));
     }
 
     /**

--- a/app/Services/SesV2Client.php
+++ b/app/Services/SesV2Client.php
@@ -86,6 +86,26 @@ class SesV2Client
         return $response->json();
     }
 
+    public function deleteSuppressedDestination(Source $source, string $email): void
+    {
+        $target = "https://email.{$source->ses_region}.amazonaws.com/v2/email/suppression/addresses/".rawurlencode($email);
+        $payload = '';
+        $headers = $this->signedHeaders($source, 'DELETE', $target, $payload);
+        $response = Http::withHeaders($headers)
+            ->timeout(15)
+            ->delete($target);
+
+        try {
+            $response->throw();
+        } catch (RequestException $exception) {
+            if ($exception->response?->notFound()) {
+                return;
+            }
+
+            throw $exception;
+        }
+    }
+
     /**
      * The explicit Destination is required for Bcc delivery: Symfony Mime
      * strips the Bcc header from the raw message, so SES cannot derive

--- a/app/Services/SuppressionRemovalService.php
+++ b/app/Services/SuppressionRemovalService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\SourceProvider;
+use App\Exceptions\SuppressionProviderUnavailableException;
 use App\Exceptions\SuppressionRemovalException;
 use App\Models\Suppression;
 use Illuminate\Support\Str;
@@ -29,8 +30,10 @@ class SuppressionRemovalService
             try {
                 $this->ses->deleteSuppressedDestination($source, $suppression->email);
             } catch (Throwable $exception) {
-                throw new SuppressionRemovalException(
-                    'Amazon SES could not remove this address. The local blocker was preserved. '.$exception->getMessage(),
+                report($exception);
+
+                throw new SuppressionProviderUnavailableException(
+                    'Amazon SES could not remove this address right now. The local blocker was preserved. Try again later.',
                     previous: $exception,
                 );
             }
@@ -41,10 +44,12 @@ class SuppressionRemovalService
         }
 
         try {
-            $upstreamSuppressions = $this->cloudflare->listSuppressions($source);
+            $upstreamSuppressions = $this->cloudflare->listStableSuppressions($source);
         } catch (Throwable $exception) {
-            throw new SuppressionRemovalException(
-                'Cloudflare could not confirm whether this address is still suppressed. The local blocker was preserved. '.$exception->getMessage(),
+            report($exception);
+
+            throw new SuppressionProviderUnavailableException(
+                'Cloudflare could not verify this address right now. The local blocker was preserved. Try again later.',
                 previous: $exception,
             );
         }

--- a/app/Services/SuppressionRemovalService.php
+++ b/app/Services/SuppressionRemovalService.php
@@ -6,7 +6,6 @@ use App\Enums\SourceProvider;
 use App\Exceptions\SuppressionProviderUnavailableException;
 use App\Exceptions\SuppressionRemovalException;
 use App\Models\Suppression;
-use Illuminate\Support\Str;
 use Throwable;
 
 class SuppressionRemovalService
@@ -59,9 +58,11 @@ class SuppressionRemovalService
             );
         }
 
-        $email = Str::lower($suppression->email);
+        $email = Suppression::normalizeEmail($suppression->email);
         $stillSuppressed = collect($upstreamSuppressions)
-            ->contains(fn (array $upstream): bool => Str::lower($upstream['email']) === $email);
+            ->contains(
+                fn (array $upstream): bool => Suppression::normalizeEmail($upstream['email']) === $email,
+            );
 
         if ($stillSuppressed) {
             throw new SuppressionRemovalException(

--- a/app/Services/SuppressionRemovalService.php
+++ b/app/Services/SuppressionRemovalService.php
@@ -11,6 +11,8 @@ use Throwable;
 
 class SuppressionRemovalService
 {
+    private const CLOUDFLARE_SNAPSHOT_BUDGET_SECONDS = 10;
+
     public function __construct(
         private SesV2Client $ses,
         private CloudflareApiClient $cloudflare,
@@ -44,7 +46,10 @@ class SuppressionRemovalService
         }
 
         try {
-            $upstreamSuppressions = $this->cloudflare->listStableSuppressions($source);
+            $upstreamSuppressions = $this->cloudflare->listStableSuppressions(
+                $source,
+                self::CLOUDFLARE_SNAPSHOT_BUDGET_SECONDS,
+            );
         } catch (Throwable $exception) {
             report($exception);
 

--- a/app/Services/SuppressionRemovalService.php
+++ b/app/Services/SuppressionRemovalService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\SourceProvider;
+use App\Exceptions\SuppressionRemovalException;
+use App\Models\Suppression;
+use Illuminate\Support\Str;
+use Throwable;
+
+class SuppressionRemovalService
+{
+    public function __construct(
+        private SesV2Client $ses,
+        private CloudflareApiClient $cloudflare,
+    ) {}
+
+    public function remove(Suppression $suppression): void
+    {
+        $source = $suppression->source;
+
+        if ($source === null) {
+            $suppression->delete();
+
+            return;
+        }
+
+        if ($source->provider === SourceProvider::Ses) {
+            try {
+                $this->ses->deleteSuppressedDestination($source, $suppression->email);
+            } catch (Throwable $exception) {
+                throw new SuppressionRemovalException(
+                    'Amazon SES could not remove this address. The local blocker was preserved. '.$exception->getMessage(),
+                    previous: $exception,
+                );
+            }
+
+            $suppression->delete();
+
+            return;
+        }
+
+        try {
+            $upstreamSuppressions = $this->cloudflare->listSuppressions($source);
+        } catch (Throwable $exception) {
+            throw new SuppressionRemovalException(
+                'Cloudflare could not confirm whether this address is still suppressed. The local blocker was preserved. '.$exception->getMessage(),
+                previous: $exception,
+            );
+        }
+
+        $email = Str::lower($suppression->email);
+        $stillSuppressed = collect($upstreamSuppressions)
+            ->contains(fn (array $upstream): bool => Str::lower($upstream['email']) === $email);
+
+        if ($stillSuppressed) {
+            throw new SuppressionRemovalException(
+                'Cloudflare still lists this address upstream and does not provide a suppression-removal API. Remove it in Cloudflare first, then retry.',
+            );
+        }
+
+        $suppression->delete();
+    }
+}

--- a/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
+++ b/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
@@ -1,0 +1,180 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const NORMALIZED_UNIQUE_INDEX = 'suppressions_project_normalized_email_unique';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $migrationStartedAt = CarbonImmutable::now();
+
+        DB::transaction(function () use ($migrationStartedAt): void {
+            $this->consolidateCaseVariants($migrationStartedAt);
+
+            DB::table('suppressions')->update([
+                'email' => DB::raw('LOWER(TRIM(email))'),
+            ]);
+        });
+        $this->addNormalizedUniqueIndex();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if (in_array($driver, ['mysql', 'mariadb', 'sqlsrv'], true)) {
+            Schema::table('suppressions', function (Blueprint $table): void {
+                $table->dropUnique(self::NORMALIZED_UNIQUE_INDEX);
+                $table->dropColumn('normalized_email');
+            });
+
+            return;
+        }
+
+        if (in_array($driver, ['pgsql', 'sqlite'], true)) {
+            DB::statement('DROP INDEX IF EXISTS '.self::NORMALIZED_UNIQUE_INDEX);
+
+            return;
+        }
+
+        throw new RuntimeException("Unsupported database driver [{$driver}].");
+    }
+
+    private function consolidateCaseVariants(CarbonImmutable $migrationStartedAt): void
+    {
+        $duplicateGroups = DB::table('suppressions')
+            ->select('project_id')
+            ->selectRaw('LOWER(TRIM(email)) AS normalized_email')
+            ->groupBy('project_id')
+            ->groupByRaw('LOWER(TRIM(email))')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($duplicateGroups as $group) {
+            $suppressions = DB::table('suppressions')
+                ->where('project_id', $group->project_id)
+                ->whereRaw('LOWER(TRIM(email)) = ?', [$group->normalized_email])
+                ->get();
+
+            $keeper = $suppressions
+                ->sort(function (object $left, object $right) use ($migrationStartedAt): int {
+                    return $this->priority($right, $migrationStartedAt)
+                        <=> $this->priority($left, $migrationStartedAt);
+                })
+                ->first();
+
+            if ($keeper === null) {
+                continue;
+            }
+
+            $duplicateIds = $suppressions
+                ->where('id', '!=', $keeper->id)
+                ->pluck('id')
+                ->all();
+
+            DB::table('suppressions')->whereIn('id', $duplicateIds)->delete();
+            DB::table('suppressions')->where('id', $keeper->id)->update([
+                'email' => $group->normalized_email,
+                'expires_at' => $this->strongestExpiration($suppressions, $migrationStartedAt),
+                'updated_at' => $suppressions->max('updated_at'),
+            ]);
+        }
+    }
+
+    /**
+     * Prefer active blockers, complaints, and rows carrying local ownership.
+     * Remaining ties resolve by permanence, recency, then id.
+     *
+     * @return array<int, int>
+     */
+    private function priority(object $suppression, CarbonImmutable $migrationStartedAt): array
+    {
+        return [
+            (int) $this->isActive($suppression, $migrationStartedAt),
+            (int) ($suppression->reason === 'complaint' || $suppression->event_type === 'complaint'),
+            (int) ($suppression->event_type !== 'provider_sync'),
+            (int) ($suppression->email_id !== null),
+            (int) ($suppression->source_id !== null),
+            (int) ($suppression->expires_at === null),
+            $this->timestamp($suppression->updated_at),
+            (int) $suppression->id,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, object>  $suppressions
+     */
+    private function strongestExpiration(Collection $suppressions, CarbonImmutable $migrationStartedAt): ?string
+    {
+        $activeSuppressions = $suppressions
+            ->filter(fn (object $suppression): bool => $this->isActive($suppression, $migrationStartedAt));
+
+        if ($activeSuppressions->contains(fn (object $suppression): bool => $suppression->expires_at === null)) {
+            return null;
+        }
+
+        return $activeSuppressions->isNotEmpty()
+            ? $activeSuppressions->max('expires_at')
+            : $suppressions->max('expires_at');
+    }
+
+    private function isActive(object $suppression, CarbonImmutable $migrationStartedAt): bool
+    {
+        return $suppression->expires_at === null
+            || CarbonImmutable::parse($suppression->expires_at)->isAfter($migrationStartedAt);
+    }
+
+    private function timestamp(mixed $value): int
+    {
+        return $value === null ? PHP_INT_MIN : CarbonImmutable::parse($value)->getTimestamp();
+    }
+
+    private function addNormalizedUniqueIndex(): void
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if (in_array($driver, ['pgsql', 'sqlite'], true)) {
+            DB::statement(
+                'CREATE UNIQUE INDEX '.self::NORMALIZED_UNIQUE_INDEX
+                .' ON suppressions (project_id, LOWER(TRIM(email)))',
+            );
+
+            return;
+        }
+
+        if (in_array($driver, ['mysql', 'mariadb'], true)) {
+            Schema::table('suppressions', function (Blueprint $table): void {
+                $table->string('normalized_email')
+                    ->storedAs('LOWER(TRIM(email))');
+                $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
+            });
+
+            return;
+        }
+
+        if ($driver === 'sqlsrv') {
+            Schema::table('suppressions', function (Blueprint $table): void {
+                $table->computed('normalized_email', 'LOWER(TRIM([email]))')
+                    ->persisted();
+                $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
+            });
+
+            return;
+        }
+
+        throw new RuntimeException("Unsupported database driver [{$driver}].");
+    }
+};

--- a/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
+++ b/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
@@ -11,6 +11,8 @@ return new class extends Migration
 {
     private const NORMALIZED_UNIQUE_INDEX = 'suppressions_project_normalized_email_unique';
 
+    private const ORIGINAL_UNIQUE_INDEX = 'suppressions_project_id_email_unique';
+
     /**
      * Run the migrations.
      */
@@ -36,10 +38,22 @@ return new class extends Migration
     {
         $driver = DB::connection()->getDriverName();
 
-        if (in_array($driver, ['mysql', 'mariadb', 'sqlsrv'], true)) {
+        if (in_array($driver, ['mysql', 'mariadb'], true)) {
+            DB::statement(
+                'ALTER TABLE `suppressions`'
+                .' DROP INDEX `'.self::NORMALIZED_UNIQUE_INDEX.'`,'
+                .' DROP COLUMN `normalized_email`,'
+                .' ADD UNIQUE INDEX `'.self::ORIGINAL_UNIQUE_INDEX.'` (`project_id`, `email`)',
+            );
+
+            return;
+        }
+
+        if ($driver === 'sqlsrv') {
             Schema::table('suppressions', function (Blueprint $table): void {
                 $table->dropUnique(self::NORMALIZED_UNIQUE_INDEX);
                 $table->dropColumn('normalized_email');
+                $table->unique(['project_id', 'email'], self::ORIGINAL_UNIQUE_INDEX);
             });
 
             return;
@@ -164,18 +178,24 @@ return new class extends Migration
         }
 
         if (in_array($driver, ['mysql', 'mariadb'], true)) {
-            Schema::table('suppressions', function (Blueprint $table): void {
-                $table->string('normalized_email')
-                    ->storedAs($this->normalizedEmailExpression());
-                $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
-            });
+            DB::statement(
+                'ALTER TABLE `suppressions`'
+                .' DROP INDEX `'.self::ORIGINAL_UNIQUE_INDEX.'`,'
+                .' ADD COLUMN `normalized_email` VARBINARY(1020)'
+                ." GENERATED ALWAYS AS (CAST({$normalizedEmailExpression} AS BINARY)) STORED,"
+                .' ADD UNIQUE INDEX `'.self::NORMALIZED_UNIQUE_INDEX.'` (`project_id`, `normalized_email`)',
+            );
 
             return;
         }
 
         if ($driver === 'sqlsrv') {
             Schema::table('suppressions', function (Blueprint $table): void {
-                $table->computed('normalized_email', $this->normalizedEmailExpression())
+                $table->dropUnique(self::ORIGINAL_UNIQUE_INDEX);
+                $table->computed(
+                    'normalized_email',
+                    $this->normalizedEmailExpression().' COLLATE Latin1_General_100_BIN2',
+                )
                     ->persisted();
                 $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
             });

--- a/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
+++ b/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\CarbonImmutable;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
@@ -36,13 +37,18 @@ return new class extends Migration
      */
     public function down(): void
     {
-        $driver = DB::connection()->getDriverName();
+        $connection = DB::connection();
+        $driver = $connection->getDriverName();
+
+        if (in_array($driver, ['mysql', 'mariadb', 'sqlsrv'], true)) {
+            $this->assertLegacyUniqueIndexCanBeRestored($connection);
+        }
 
         if (in_array($driver, ['mysql', 'mariadb'], true)) {
             DB::statement(
                 'ALTER TABLE `suppressions`'
                 .' DROP INDEX `'.self::NORMALIZED_UNIQUE_INDEX.'`,'
-                .' DROP COLUMN `normalized_email`,'
+                .' DROP COLUMN `email_normalized`,'
                 .' ADD UNIQUE INDEX `'.self::ORIGINAL_UNIQUE_INDEX.'` (`project_id`, `email`)',
             );
 
@@ -52,7 +58,7 @@ return new class extends Migration
         if ($driver === 'sqlsrv') {
             Schema::table('suppressions', function (Blueprint $table): void {
                 $table->dropUnique(self::NORMALIZED_UNIQUE_INDEX);
-                $table->dropColumn('normalized_email');
+                $table->dropColumn('email_normalized');
                 $table->unique(['project_id', 'email'], self::ORIGINAL_UNIQUE_INDEX);
             });
 
@@ -66,6 +72,26 @@ return new class extends Migration
         }
 
         throw new RuntimeException("Unsupported database driver [{$driver}].");
+    }
+
+    private function assertLegacyUniqueIndexCanBeRestored(ConnectionInterface $connection): void
+    {
+        $conflict = $connection->table('suppressions')
+            ->select('project_id')
+            ->selectRaw('MIN(email) AS email')
+            ->groupBy('project_id', 'email')
+            ->havingRaw('COUNT(*) > 1')
+            ->first();
+
+        if ($conflict === null) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'Legacy suppression uniqueness cannot be restored losslessly because '
+            ."project [{$conflict->project_id}] contains email values that collide under the legacy database collation. "
+            .'Remove or consolidate those suppression rows before rolling back this migration.',
+        );
     }
 
     private function consolidateCaseVariants(CarbonImmutable $migrationStartedAt): void
@@ -181,9 +207,9 @@ return new class extends Migration
             DB::statement(
                 'ALTER TABLE `suppressions`'
                 .' DROP INDEX `'.self::ORIGINAL_UNIQUE_INDEX.'`,'
-                .' ADD COLUMN `normalized_email` VARBINARY(1020)'
+                .' ADD COLUMN `email_normalized` VARBINARY(1020)'
                 ." GENERATED ALWAYS AS (CAST({$normalizedEmailExpression} AS BINARY)) STORED,"
-                .' ADD UNIQUE INDEX `'.self::NORMALIZED_UNIQUE_INDEX.'` (`project_id`, `normalized_email`)',
+                .' ADD UNIQUE INDEX `'.self::NORMALIZED_UNIQUE_INDEX.'` (`project_id`, `email_normalized`)',
             );
 
             return;
@@ -193,11 +219,11 @@ return new class extends Migration
             Schema::table('suppressions', function (Blueprint $table): void {
                 $table->dropUnique(self::ORIGINAL_UNIQUE_INDEX);
                 $table->computed(
-                    'normalized_email',
-                    $this->normalizedEmailExpression().' COLLATE Latin1_General_100_BIN2',
+                    'email_normalized',
+                    $this->normalizedEmailExpression(),
                 )
                     ->persisted();
-                $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
+                $table->unique(['project_id', 'email_normalized'], self::NORMALIZED_UNIQUE_INDEX);
             });
 
             return;
@@ -212,7 +238,9 @@ return new class extends Migration
      */
     private function normalizedEmailExpression(): string
     {
-        $expression = 'TRIM(email)';
+        $expression = DB::connection()->getDriverName() === 'sqlsrv'
+            ? 'TRIM(email COLLATE Latin1_General_100_BIN2)'
+            : 'TRIM(email)';
 
         foreach (range('A', 'Z') as $uppercase) {
             $expression = sprintf(

--- a/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
+++ b/database/migrations/2026_07_24_201708_normalize_suppression_emails_and_enforce_unique_index.php
@@ -22,9 +22,10 @@ return new class extends Migration
             $this->consolidateCaseVariants($migrationStartedAt);
 
             DB::table('suppressions')->update([
-                'email' => DB::raw('LOWER(TRIM(email))'),
+                'email' => DB::raw($this->normalizedEmailExpression()),
             ]);
         });
+
         $this->addNormalizedUniqueIndex();
     }
 
@@ -55,18 +56,24 @@ return new class extends Migration
 
     private function consolidateCaseVariants(CarbonImmutable $migrationStartedAt): void
     {
+        $normalizedEmailExpression = $this->normalizedEmailExpression();
         $duplicateGroups = DB::table('suppressions')
             ->select('project_id')
-            ->selectRaw('LOWER(TRIM(email)) AS normalized_email')
+            ->selectRaw("{$normalizedEmailExpression} AS normalized_email")
             ->groupBy('project_id')
-            ->groupByRaw('LOWER(TRIM(email))')
+            ->groupByRaw($normalizedEmailExpression)
             ->havingRaw('COUNT(*) > 1')
             ->get();
 
         foreach ($duplicateGroups as $group) {
+            // PostgreSQL/MySQL lock each affected row through consolidation.
+            // SQLite omits FOR UPDATE and instead serializes writers at the
+            // database level, aborting a conflicting migration for retry.
             $suppressions = DB::table('suppressions')
                 ->where('project_id', $group->project_id)
-                ->whereRaw('LOWER(TRIM(email)) = ?', [$group->normalized_email])
+                ->whereRaw("{$normalizedEmailExpression} = ?", [$group->normalized_email])
+                ->orderBy('id')
+                ->lockForUpdate()
                 ->get();
 
             $keeper = $suppressions
@@ -95,7 +102,7 @@ return new class extends Migration
     }
 
     /**
-     * Prefer active blockers, complaints, and rows carrying local ownership.
+     * Prefer active blockers and local ownership before blocker reason.
      * Remaining ties resolve by permanence, recency, then id.
      *
      * @return array<int, int>
@@ -104,10 +111,10 @@ return new class extends Migration
     {
         return [
             (int) $this->isActive($suppression, $migrationStartedAt),
-            (int) ($suppression->reason === 'complaint' || $suppression->event_type === 'complaint'),
             (int) ($suppression->event_type !== 'provider_sync'),
             (int) ($suppression->email_id !== null),
             (int) ($suppression->source_id !== null),
+            (int) ($suppression->reason === 'complaint' || $suppression->event_type === 'complaint'),
             (int) ($suppression->expires_at === null),
             $this->timestamp($suppression->updated_at),
             (int) $suppression->id,
@@ -145,11 +152,12 @@ return new class extends Migration
     private function addNormalizedUniqueIndex(): void
     {
         $driver = DB::connection()->getDriverName();
+        $normalizedEmailExpression = $this->normalizedEmailExpression();
 
         if (in_array($driver, ['pgsql', 'sqlite'], true)) {
             DB::statement(
                 'CREATE UNIQUE INDEX '.self::NORMALIZED_UNIQUE_INDEX
-                .' ON suppressions (project_id, LOWER(TRIM(email)))',
+                ." ON suppressions (project_id, {$normalizedEmailExpression})",
             );
 
             return;
@@ -158,7 +166,7 @@ return new class extends Migration
         if (in_array($driver, ['mysql', 'mariadb'], true)) {
             Schema::table('suppressions', function (Blueprint $table): void {
                 $table->string('normalized_email')
-                    ->storedAs('LOWER(TRIM(email))');
+                    ->storedAs($this->normalizedEmailExpression());
                 $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
             });
 
@@ -167,7 +175,7 @@ return new class extends Migration
 
         if ($driver === 'sqlsrv') {
             Schema::table('suppressions', function (Blueprint $table): void {
-                $table->computed('normalized_email', 'LOWER(TRIM([email]))')
+                $table->computed('normalized_email', $this->normalizedEmailExpression())
                     ->persisted();
                 $table->unique(['project_id', 'normalized_email'], self::NORMALIZED_UNIQUE_INDEX);
             });
@@ -176,5 +184,25 @@ return new class extends Migration
         }
 
         throw new RuntimeException("Unsupported database driver [{$driver}].");
+    }
+
+    /**
+     * Fold only ASCII A-Z and trim only ASCII spaces so PHP and every
+     * supported database apply the same byte-for-byte normalization.
+     */
+    private function normalizedEmailExpression(): string
+    {
+        $expression = 'TRIM(email)';
+
+        foreach (range('A', 'Z') as $uppercase) {
+            $expression = sprintf(
+                "REPLACE(%s, '%s', '%s')",
+                $expression,
+                $uppercase,
+                strtolower($uppercase),
+            );
+        }
+
+        return $expression;
     }
 };

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -117,6 +117,8 @@ type SuppressionRow = {
     source: string;
     added: string;
     expires: string;
+    active: boolean;
+    expires_at: string | null;
 };
 
 type ProjectOption = {
@@ -161,7 +163,7 @@ type WorkspaceMemberRole =
     | 'domains'
     | 'read_only';
 
-type ApiKeyScope = 'send' | 'read:activity';
+type ApiKeyScope = 'send' | 'read:activity' | 'manage:suppressions';
 
 type ConfirmationState = {
     title: string;
@@ -188,6 +190,7 @@ const props = defineProps<{
         can_manage_members: boolean;
         can_manage_api_keys: boolean;
         can_manage_domains: boolean;
+        can_manage_suppressions: boolean;
         can_send: boolean;
     };
     workspaceMembers: {
@@ -296,6 +299,12 @@ const props = defineProps<{
     webhookStats: BounceMetric[];
     webhookDeliveries: WebhookDeliveryRow[];
     suppressions: SuppressionRow[];
+    suppressionStats: {
+        active: number;
+        hard_bounce: number;
+        complaint: number;
+        expired: number;
+    };
     newWebhookEndpoint: NewWebhookEndpoint | null;
     sesWebhookUrl: string | null;
     apiKeys: {
@@ -373,6 +382,7 @@ const revealedWebhookEndpoint = ref(props.newWebhookEndpoint);
 const webhookSecretCopied = ref(false);
 const checkingDomainId = ref<number | null>(null);
 const deletingDomainId = ref<number | null>(null);
+const removingSuppressionId = ref<number | null>(null);
 const copiedDnsKey = ref<string | null>(null);
 const inspectorWidth = ref(600);
 const mailLayoutStyle = computed<Record<string, string>>(() => ({
@@ -492,6 +502,7 @@ const workspaceRoleOptions: {
 const apiKeyScopeOptions: { value: ApiKeyScope; label: string }[] = [
     { value: 'send', label: 'Send email' },
     { value: 'read:activity', label: 'Read activity' },
+    { value: 'manage:suppressions', label: 'Manage suppressions' },
 ];
 
 const filteredEmails = computed(() => {
@@ -533,16 +544,11 @@ const complaintRows = computed(() =>
 );
 
 const suppressionRows = computed(() => props.suppressions);
-const bounceSuppressionCount = computed(
-    () =>
-        suppressionRows.value.filter((row) => row.reason === 'hard_bounce')
-            .length,
-);
-const complaintSuppressionCount = computed(
-    () =>
-        suppressionRows.value.filter((row) => row.reason === 'complaint')
-            .length,
-);
+const suppressionError = computed(() => {
+    const errors = page.props.errors as Record<string, string> | undefined;
+
+    return errors?.suppression ?? null;
+});
 const lastComplaintTime = computed(
     () => complaintRows.value[0]?.time ?? 'Never',
 );
@@ -1075,7 +1081,16 @@ function toggleApiKeyScope(scope: ApiKeyScope): void {
 }
 
 function apiKeyScopes(apiKey: { scopes: ApiKeyScope[] | null }): ApiKeyScope[] {
-    return apiKey.scopes?.length ? apiKey.scopes : ['send', 'read:activity'];
+    return apiKey.scopes?.length
+        ? apiKey.scopes
+        : ['send', 'read:activity', 'manage:suppressions'];
+}
+
+function apiKeyScopeLabel(scope: ApiKeyScope): string {
+    return (
+        apiKeyScopeOptions.find((option) => option.value === scope)?.label ??
+        scope
+    );
 }
 
 function rotateApiKey(apiKey: { id: number; name: string }): void {
@@ -1103,6 +1118,34 @@ function deleteApiKey(apiKey: { id: number; name: string }): void {
         onConfirm: () => {
             router.delete(projectAction(`/api-keys/${apiKey.id}`), {
                 preserveScroll: true,
+            });
+        },
+    });
+}
+
+function removeSuppression(suppression: SuppressionRow): void {
+    if (removingSuppressionId.value !== null) {
+        return;
+    }
+
+    openConfirmation({
+        title: `Remove ${suppression.email}?`,
+        body: isCloudflare.value
+            ? 'Larasend will verify this recipient is no longer on the Cloudflare suppression list before deleting the local record. Remove it in Cloudflare first if it is still listed there.'
+            : `Larasend will remove this recipient from ${providerLabel.value} before deleting the local record. If the provider request fails, the suppression will remain in Larasend.`,
+        actionLabel: 'Remove suppression',
+        tone: 'danger',
+        onConfirm: () => {
+            if (removingSuppressionId.value !== null) {
+                return;
+            }
+
+            removingSuppressionId.value = suppression.id;
+            router.delete(projectAction(`/suppressions/${suppression.id}`), {
+                preserveScroll: true,
+                onFinish: () => {
+                    removingSuppressionId.value = null;
+                },
             });
         },
     });
@@ -1991,7 +2034,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 Suppressed
                             </div>
                             <div class="mt-1 font-sans text-xl font-semibold">
-                                {{ complaintSuppressionCount }}
+                                {{ suppressionStats.complaint }}
                             </div>
                             <div
                                 class="mt-0.5 font-mono text-[11.5px] text-zinc-500 dark:text-[#9aa0a6]"
@@ -4535,7 +4578,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                                         v-for="scope in apiKeyScopes(apiKey)"
                                         :key="`${apiKey.id}-${scope}`"
                                         class="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[11px] text-zinc-500 dark:bg-[#1a1e22]"
-                                        >{{ scope }}</span
+                                        >{{ apiKeyScopeLabel(scope) }}</span
                                     >
                                 </div>
                                 <div
@@ -4601,7 +4644,7 @@ function recipientTitle(email: EmailRow): string | undefined {
 
                     <div v-else class="grid gap-4">
                         <section
-                            class="grid grid-cols-5 overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-[#1d2125] dark:bg-[#111315]"
+                            class="grid grid-cols-2 overflow-hidden rounded-lg border border-zinc-200 bg-white lg:grid-cols-5 dark:border-[#1d2125] dark:bg-[#111315]"
                         >
                             <div
                                 class="border-r border-zinc-200 px-3 py-2.5 dark:border-[#1d2125]"
@@ -4609,15 +4652,15 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 <div
                                     class="font-mono text-[11px] tracking-widest text-zinc-500 uppercase"
                                 >
-                                    Suppressed
+                                    Active
                                 </div>
                                 <div class="mt-3 text-xl font-semibold">
-                                    {{ suppressionRows.length }}
+                                    {{ suppressionStats.active }}
                                 </div>
                                 <div
-                                    class="mt-1 font-mono text-[12px] text-zinc-500"
+                                    class="mt-1 font-mono text-[12px] text-emerald-600 dark:text-emerald-400"
                                 >
-                                    total
+                                    blocked
                                 </div>
                             </div>
                             <div
@@ -4629,10 +4672,10 @@ function recipientTitle(email: EmailRow): string | undefined {
                                     Bounces
                                 </div>
                                 <div class="mt-3 text-xl font-semibold">
-                                    {{ bounceSuppressionCount }}
+                                    {{ suppressionStats.hard_bounce }}
                                 </div>
                                 <div
-                                    class="mt-1 font-mono text-[12px] text-red-400"
+                                    class="mt-1 font-mono text-[12px] text-red-600 dark:text-red-400"
                                 >
                                     blocked
                                 </div>
@@ -4646,10 +4689,10 @@ function recipientTitle(email: EmailRow): string | undefined {
                                     Complaints
                                 </div>
                                 <div class="mt-3 text-xl font-semibold">
-                                    {{ complaintSuppressionCount }}
+                                    {{ suppressionStats.complaint }}
                                 </div>
                                 <div
-                                    class="mt-1 font-mono text-[12px] text-violet-400"
+                                    class="mt-1 font-mono text-[12px] text-violet-600 dark:text-violet-400"
                                 >
                                     blocked
                                 </div>
@@ -4660,13 +4703,15 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 <div
                                     class="font-mono text-[11px] tracking-widest text-zinc-500 uppercase"
                                 >
-                                    Manual
+                                    Expired
                                 </div>
-                                <div class="mt-3 text-xl font-semibold">0</div>
+                                <div class="mt-3 text-xl font-semibold">
+                                    {{ suppressionStats.expired }}
+                                </div>
                                 <div
                                     class="mt-1 font-mono text-[12px] text-zinc-500"
                                 >
-                                    list
+                                    history
                                 </div>
                             </div>
                             <div class="px-3 py-2.5">
@@ -4679,7 +4724,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                                     Active
                                 </div>
                                 <div
-                                    class="mt-1 font-mono text-[12px] text-emerald-400"
+                                    class="mt-1 font-mono text-[12px] text-emerald-600 dark:text-emerald-400"
                                 >
                                     enforced
                                 </div>
@@ -4705,21 +4750,30 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 </a>
                             </div>
                             <div
-                                class="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-[#1d2125] dark:bg-[#0b0c0d]"
+                                v-if="suppressionError"
+                                role="alert"
+                                class="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300"
+                            >
+                                {{ suppressionError }}
+                            </div>
+                            <div
+                                class="overflow-x-auto rounded-lg border border-zinc-200 bg-white dark:border-[#1d2125] dark:bg-[#0b0c0d]"
                             >
                                 <div
-                                    class="grid grid-cols-[minmax(260px,1fr)_150px_220px_140px_130px] border-b border-zinc-200 bg-zinc-50 px-3 py-2 font-mono text-[11px] tracking-widest text-zinc-500 uppercase dark:border-[#1d2125] dark:bg-[#111315]"
+                                    class="grid min-w-[1100px] grid-cols-[minmax(240px,1fr)_140px_180px_110px_120px_100px_130px] border-b border-zinc-200 bg-zinc-50 px-3 py-2 font-mono text-[11px] tracking-widest text-zinc-500 uppercase dark:border-[#1d2125] dark:bg-[#111315]"
                                 >
                                     <div>Recipient</div>
                                     <div>Reason</div>
                                     <div>Source</div>
                                     <div>Added</div>
                                     <div>Expires</div>
+                                    <div>Status</div>
+                                    <div>Actions</div>
                                 </div>
                                 <div
                                     v-for="email in suppressionRows"
                                     :key="email.id"
-                                    class="grid h-11 grid-cols-[minmax(260px,1fr)_150px_220px_140px_130px] items-center border-b border-zinc-200 px-3 text-[13px] last:border-b-0 dark:border-[#16191c]"
+                                    class="grid min-h-12 min-w-[1100px] grid-cols-[minmax(240px,1fr)_140px_180px_110px_120px_100px_130px] items-center border-b border-zinc-200 px-3 text-[13px] last:border-b-0 dark:border-[#16191c]"
                                 >
                                     <div class="truncate">
                                         {{ email.email }}
@@ -4749,6 +4803,56 @@ function recipientTitle(email: EmailRow): string | undefined {
                                         class="font-mono text-[12px] text-zinc-500"
                                     >
                                         {{ email.expires }}
+                                    </div>
+                                    <div>
+                                        <span
+                                            class="rounded px-1.5 py-0.5 font-mono text-[11px]"
+                                            :title="
+                                                email.expires_at
+                                                    ? `Expiration: ${email.expires}`
+                                                    : 'No expiration date'
+                                            "
+                                            :class="
+                                                email.active
+                                                    ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300'
+                                                    : 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
+                                            "
+                                        >
+                                            {{
+                                                email.active
+                                                    ? 'Active'
+                                                    : 'Expired'
+                                            }}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <button
+                                            v-if="
+                                                workspace.can_manage_suppressions
+                                            "
+                                            type="button"
+                                            class="inline-flex items-center gap-1.5 rounded-md border border-red-200 px-2.5 py-1.5 text-[11px] font-semibold text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500/30 dark:text-red-300 dark:hover:bg-red-500/10"
+                                            :disabled="
+                                                removingSuppressionId !== null
+                                            "
+                                            title="Remove suppression"
+                                            @click="removeSuppression(email)"
+                                        >
+                                            <RefreshCw
+                                                v-if="
+                                                    removingSuppressionId ===
+                                                    email.id
+                                                "
+                                                class="size-3 animate-spin"
+                                            />
+                                            <Trash2 v-else class="size-3" />
+                                            {{
+                                                removingSuppressionId ===
+                                                email.id
+                                                    ? 'Removing...'
+                                                    : 'Remove'
+                                            }}
+                                        </button>
                                     </div>
                                 </div>
                                 <div

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -1082,9 +1082,11 @@ function toggleApiKeyScope(scope: ApiKeyScope): void {
 }
 
 function apiKeyScopes(apiKey: { scopes: ApiKeyScope[] | null }): ApiKeyScope[] {
-    return apiKey.scopes?.length
-        ? apiKey.scopes
-        : ['send', 'read:activity', 'manage:suppressions'];
+    if (apiKey.scopes === null) {
+        return ['send', 'read:activity', 'manage:suppressions'];
+    }
+
+    return apiKey.scopes;
 }
 
 function apiKeyScopeLabel(scope: ApiKeyScope): string {

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -115,6 +115,7 @@ type SuppressionRow = {
     email: string;
     reason: string;
     source: string;
+    provider: SourceProvider | null;
     added: string;
     expires: string;
     active: boolean;
@@ -1123,6 +1124,18 @@ function deleteApiKey(apiKey: { id: number; name: string }): void {
     });
 }
 
+function suppressionRemovalCopy(suppression: SuppressionRow): string {
+    if (suppression.provider === 'cloudflare') {
+        return 'Larasend will verify this recipient is no longer on the Cloudflare suppression list before deleting the local record. Remove it in Cloudflare first if it is still listed there.';
+    }
+
+    if (suppression.provider === 'ses') {
+        return 'Larasend will remove this recipient from Amazon SES before deleting the local record. If the provider request fails, the suppression will remain in Larasend.';
+    }
+
+    return 'Larasend will remove this local suppression record. No sending provider is attached, so no provider suppression will be changed.';
+}
+
 function removeSuppression(suppression: SuppressionRow): void {
     if (removingSuppressionId.value !== null) {
         return;
@@ -1130,9 +1143,7 @@ function removeSuppression(suppression: SuppressionRow): void {
 
     openConfirmation({
         title: `Remove ${suppression.email}?`,
-        body: isCloudflare.value
-            ? 'Larasend will verify this recipient is no longer on the Cloudflare suppression list before deleting the local record. Remove it in Cloudflare first if it is still listed there.'
-            : `Larasend will remove this recipient from ${providerLabel.value} before deleting the local record. If the provider request fails, the suppression will remain in Larasend.`,
+        body: suppressionRemovalCopy(suppression),
         actionLabel: 'Remove suppression',
         tone: 'danger',
         onConfirm: () => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,15 +1,17 @@
 <?php
 
 use App\Http\Controllers\Api\EmailController;
+use App\Http\Controllers\Api\SuppressionController;
 use App\Http\Controllers\Webhooks\CloudflareInboundController;
 use App\Http\Controllers\Webhooks\SesWebhookController;
 use App\Http\Middleware\AuthenticateLarasendApiKey;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(AuthenticateLarasendApiKey::class)->group(function () {
-    Route::get('emails', [EmailController::class, 'index']);
-    Route::post('emails', [EmailController::class, 'store']);
-    Route::get('emails/{email}', [EmailController::class, 'show']);
+    Route::get('emails', [EmailController::class, 'index'])->name('api.emails.index');
+    Route::post('emails', [EmailController::class, 'store'])->name('api.emails.store');
+    Route::get('emails/{email}', [EmailController::class, 'show'])->name('api.emails.show');
+    Route::delete('suppressions/{suppression}', [SuppressionController::class, 'destroy'])->name('api.suppressions.destroy');
 });
 
 Route::post('webhooks/ses/{token}', SesWebhookController::class)

--- a/routes/console.php
+++ b/routes/console.php
@@ -15,6 +15,6 @@ Artisan::command('inspire', function () {
 Schedule::call(fn () => app(SystemHealth::class)->recordSchedulerHeartbeat())
     ->everyMinute()
     ->name('scheduler-heartbeat');
-Schedule::job(new SyncCloudflareSuppressions)->hourly();
+Schedule::job(new SyncCloudflareSuppressions)->hourly()->withoutOverlapping();
 Schedule::job(new RecheckPendingDomains)->everyTenMinutes()->withoutOverlapping();
 Schedule::job(new SyncStaleSourceQuotas)->everyThirtyMinutes()->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('api-keys', [DashboardActionController::class, 'storeApiKey'])->name('api-keys.store');
         Route::post('api-keys/{apiKey}/rotate', [DashboardActionController::class, 'rotateApiKey'])->name('api-keys.rotate');
         Route::delete('api-keys/{apiKey}', [DashboardActionController::class, 'destroyApiKey'])->name('api-keys.destroy');
+        Route::delete('suppressions/{suppression}', [DashboardActionController::class, 'destroyProjectSuppression'])->name('suppressions.destroy');
         Route::post('webhooks', [DashboardActionController::class, 'storeWebhookEndpoint'])->name('webhooks.store');
         Route::put('webhooks/{endpoint:public_id}', [DashboardActionController::class, 'updateWebhookEndpoint'])->name('webhooks.update');
         Route::post('send', [DashboardActionController::class, 'sendEmail'])->name('send.store');
@@ -90,6 +91,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('bounces', ActivityController::class)->defaults('section', 'bounces')->name('bounces');
     Route::get('complaints', ActivityController::class)->defaults('section', 'complaints')->name('complaints');
     Route::get('suppressions', ActivityController::class)->defaults('section', 'suppressions')->name('suppressions');
+    Route::delete('suppressions/{suppression}', [DashboardActionController::class, 'destroySuppression'])->name('suppressions.destroy');
     Route::get('identities', ActivityController::class)->defaults('section', 'identities')->name('identities');
     Route::get('templates', ActivityController::class)->defaults('section', 'templates')->name('templates');
     Route::get('webhooks', ActivityController::class)->defaults('section', 'webhooks')->name('webhooks');

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -459,6 +459,16 @@ it('exports suppression rows with formula-safe values', function () {
         'expires_at' => now()->subDay(),
     ]);
 
+    Suppression::query()->create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => '-recipient@example.com',
+        'reason' => "\t=reason",
+        'event_type' => "\r @provider_sync",
+        'expires_at' => now()->subDay(),
+    ]);
+
     $export = $this->actingAs($user)
         ->get('/activity/export?section=suppressions')
         ->assertSuccessful()
@@ -466,15 +476,29 @@ it('exports suppression rows with formula-safe values', function () {
         ->assertHeader('content-disposition', 'attachment; filename=larasend-suppressions.csv');
 
     $content = $export->streamedContent();
+    $stream = fopen('php://memory', 'r+');
+    fwrite($stream, $content);
+    rewind($stream);
+    $rows = [];
 
-    expect(str_getcsv(strtok($content, "\n")))
+    while (($row = fgetcsv($stream)) !== false) {
+        $rows[] = $row;
+    }
+
+    fclose($stream);
+
+    expect($rows[0])
         ->toBe(['Recipient', 'Reason', 'Source', 'Added at', 'Expires at', 'Status']);
 
-    expect($content)
-        ->toContain("'=recipient@example.com")
-        ->toContain("'+reason")
-        ->toContain("'@provider_sync")
-        ->toContain('Expired');
+    $directFormulaRow = collect($rows)->first(fn (array $row): bool => str_contains($row[0] ?? '', '=recipient@example.com'));
+    $controlWhitespaceRow = collect($rows)->first(fn (array $row): bool => str_contains($row[0] ?? '', '-recipient@example.com'));
+
+    expect(array_slice($directFormulaRow, 0, 3))
+        ->toBe(["'=recipient@example.com", "'+reason", "'@provider_sync"])
+        ->and($directFormulaRow[5])->toBe('Expired')
+        ->and(array_slice($controlWhitespaceRow, 0, 3))
+        ->toBe(["'-recipient@example.com", "'\t=reason", "'\r @provider_sync"])
+        ->and($controlWhitespaceRow[5])->toBe('Expired');
 });
 
 it('allows workspace users to download raw mime content', function () {

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -65,24 +65,38 @@ it('returns active suppression metadata and statistics', function () {
         'expires_at' => $expiredAt,
     ]);
 
+    Suppression::query()->create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => null,
+        'email' => 'legacy@example.com',
+        'reason' => 'manual',
+        'event_type' => 'legacy',
+    ]);
+
     $this->actingAs($user)
         ->get('/suppressions')
         ->assertSuccessful()
         ->assertInertia(fn ($page) => $page
             ->where('workspace.can_manage_suppressions', true)
             ->where('suppressionStats', [
-                'active' => 2,
+                'active' => 3,
                 'hard_bounce' => 1,
                 'complaint' => 1,
                 'expired' => 1,
             ])
-            ->where('sidebarCounts.suppressions', 2)
+            ->where('sidebarCounts.suppressions', 3)
             ->where('suppressions', fn ($suppressions) => collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'expired@example.com'
                 && $suppression['active'] === false
-                && $suppression['expires_at'] === $expiredAt->toIso8601String())
+                && $suppression['expires_at'] === $expiredAt->toIso8601String()
+                && ($suppression['provider'] ?? null) === 'ses')
                 && collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'ana.delpino@gmail.com'
                     && $suppression['active'] === true
-                    && $suppression['expires_at'] === null))
+                    && $suppression['expires_at'] === null
+                    && ($suppression['provider'] ?? null) === 'ses')
+                && collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'legacy@example.com'
+                    && array_key_exists('provider', $suppression)
+                    && $suppression['provider'] === null))
         );
 });
 
@@ -95,6 +109,10 @@ it('renders suppression management and api key scope controls in the activity pa
         ->toContain('suppressionStats.active')
         ->toContain('workspace.can_manage_suppressions')
         ->toContain('removeSuppression(email)')
+        ->toContain('provider: SourceProvider | null;')
+        ->toContain("suppression.provider === 'cloudflare'")
+        ->toContain("suppression.provider === 'ses'")
+        ->toContain('No sending provider is attached')
         ->toContain('email.active')
         ->toContain("? 'Active'")
         ->toContain(": 'Expired'")

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -69,6 +69,7 @@ it('returns active suppression metadata and statistics', function () {
         ->get('/suppressions')
         ->assertSuccessful()
         ->assertInertia(fn ($page) => $page
+            ->where('workspace.can_manage_suppressions', true)
             ->where('suppressionStats', [
                 'active' => 2,
                 'hard_bounce' => 1,
@@ -83,6 +84,21 @@ it('returns active suppression metadata and statistics', function () {
                     && $suppression['active'] === true
                     && $suppression['expires_at'] === null))
         );
+});
+
+it('renders suppression management and api key scope controls in the activity page source', function () {
+    $activitySource = file_get_contents(resource_path('js/pages/Activity.vue'));
+
+    expect($activitySource)
+        ->toContain("type ApiKeyScope = 'send' | 'read:activity' | 'manage:suppressions';")
+        ->toContain("{ value: 'manage:suppressions', label: 'Manage suppressions' }")
+        ->toContain('suppressionStats.active')
+        ->toContain('workspace.can_manage_suppressions')
+        ->toContain('removeSuppression(email)')
+        ->toContain('email.active')
+        ->toContain("? 'Active'")
+        ->toContain(": 'Expired'")
+        ->toContain('<div>Actions</div>');
 });
 
 it('renders recent active inbox conversations on the dashboard', function () {

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -53,6 +53,12 @@ it('returns active suppression metadata and statistics', function () {
     $user = User::factory()->create();
     $project = seedActivityDashboardData($user);
     $source = $project->sources()->firstOrFail();
+    $cloudflareSource = $project->sources()->create([
+        'name' => 'Cloudflare',
+        'environment' => 'dev',
+        'provider' => 'cloudflare',
+        'webhook_token' => Str::random(64),
+    ]);
     $expiredAt = now()->subDay()->startOfSecond();
 
     Suppression::query()->create([
@@ -74,18 +80,27 @@ it('returns active suppression metadata and statistics', function () {
         'event_type' => 'legacy',
     ]);
 
+    Suppression::query()->create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $cloudflareSource->id,
+        'email' => 'cloudflare@example.com',
+        'reason' => 'manual',
+        'event_type' => 'provider_sync',
+    ]);
+
     $this->actingAs($user)
         ->get('/suppressions')
         ->assertSuccessful()
         ->assertInertia(fn ($page) => $page
             ->where('workspace.can_manage_suppressions', true)
             ->where('suppressionStats', [
-                'active' => 3,
+                'active' => 4,
                 'hard_bounce' => 1,
                 'complaint' => 1,
                 'expired' => 1,
             ])
-            ->where('sidebarCounts.suppressions', 3)
+            ->where('sidebarCounts.suppressions', 4)
             ->where('suppressions', fn ($suppressions) => collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'expired@example.com'
                 && $suppression['active'] === false
                 && $suppression['expires_at'] === $expiredAt->toIso8601String()
@@ -96,7 +111,9 @@ it('returns active suppression metadata and statistics', function () {
                     && ($suppression['provider'] ?? null) === 'ses')
                 && collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'legacy@example.com'
                     && array_key_exists('provider', $suppression)
-                    && $suppression['provider'] === null))
+                    && $suppression['provider'] === null)
+                && collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'cloudflare@example.com'
+                    && $suppression['provider'] === 'cloudflare'))
         );
 });
 
@@ -106,6 +123,8 @@ it('renders suppression management and api key scope controls in the activity pa
     expect($activitySource)
         ->toContain("type ApiKeyScope = 'send' | 'read:activity' | 'manage:suppressions';")
         ->toContain("{ value: 'manage:suppressions', label: 'Manage suppressions' }")
+        ->toContain('if (apiKey.scopes === null)')
+        ->toContain('return apiKey.scopes;')
         ->toContain('suppressionStats.active')
         ->toContain('workspace.can_manage_suppressions')
         ->toContain('removeSuppression(email)')

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -49,6 +49,42 @@ it('renders the activity dashboard for authenticated users', function () {
         );
 });
 
+it('returns active suppression metadata and statistics', function () {
+    $user = User::factory()->create();
+    $project = seedActivityDashboardData($user);
+    $source = $project->sources()->firstOrFail();
+    $expiredAt = now()->subDay()->startOfSecond();
+
+    Suppression::query()->create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'expired@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+        'expires_at' => $expiredAt,
+    ]);
+
+    $this->actingAs($user)
+        ->get('/suppressions')
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('suppressionStats', [
+                'active' => 2,
+                'hard_bounce' => 1,
+                'complaint' => 1,
+                'expired' => 1,
+            ])
+            ->where('sidebarCounts.suppressions', 2)
+            ->where('suppressions', fn ($suppressions) => collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'expired@example.com'
+                && $suppression['active'] === false
+                && $suppression['expires_at'] === $expiredAt->toIso8601String())
+                && collect($suppressions)->contains(fn (array $suppression) => $suppression['email'] === 'ana.delpino@gmail.com'
+                    && $suppression['active'] === true
+                    && $suppression['expires_at'] === null))
+        );
+});
+
 it('renders recent active inbox conversations on the dashboard', function () {
     $user = User::factory()->create();
     $project = seedActivityDashboardData($user);
@@ -406,6 +442,39 @@ it('filters activity by search query and exports csv', function () {
     expect($export->streamedContent())
         ->toContain('Message ID')
         ->toContain('maya.okafor@northwind.io');
+});
+
+it('exports suppression rows with formula-safe values', function () {
+    $user = User::factory()->create();
+    $project = seedActivityDashboardData($user);
+    $source = $project->sources()->firstOrFail();
+
+    Suppression::query()->create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => '=recipient@example.com',
+        'reason' => '+reason',
+        'event_type' => '@provider_sync',
+        'expires_at' => now()->subDay(),
+    ]);
+
+    $export = $this->actingAs($user)
+        ->get('/activity/export?section=suppressions')
+        ->assertSuccessful()
+        ->assertHeader('content-type', 'text/csv; charset=UTF-8')
+        ->assertHeader('content-disposition', 'attachment; filename=larasend-suppressions.csv');
+
+    $content = $export->streamedContent();
+
+    expect(str_getcsv(strtok($content, "\n")))
+        ->toBe(['Recipient', 'Reason', 'Source', 'Added at', 'Expires at', 'Status']);
+
+    expect($content)
+        ->toContain("'=recipient@example.com")
+        ->toContain("'+reason")
+        ->toContain("'@provider_sync")
+        ->toContain('Expired');
 });
 
 it('allows workspace users to download raw mime content', function () {

--- a/tests/Feature/ApiEmailTest.php
+++ b/tests/Feature/ApiEmailTest.php
@@ -8,11 +8,13 @@ use App\Models\Source;
 use App\Models\Suppression;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Services\EmailSendService;
 use App\Services\Providers\EmailProviderFactory;
 use App\Services\SesV2Client;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
 
 function larasendProjectFixture(): array
 {
@@ -255,6 +257,38 @@ it('blocks sends to suppressed recipients', function () {
 
     expect(Email::query()->count())->toBe(0);
     Queue::assertNothingPushed();
+});
+
+it('keeps non-ASCII suppression variants distinct while matching ASCII case and spaces', function () {
+    [$workspace, $project, $source] = larasendProjectFixture();
+
+    Queue::fake();
+
+    Suppression::create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => ' ÄBC@Example.com ',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+    ]);
+
+    $allowed = app(EmailSendService::class)->send($project, $source, [
+        'from' => 'Larasend <receipts@example.com>',
+        'to' => ['Distinct <äBC@example.com>'],
+        'subject' => 'Distinct non-ASCII recipient',
+        'html' => '<h1>Hello</h1>',
+        'text' => 'Hello',
+    ]);
+
+    expect($allowed->subject)->toBe('Distinct non-ASCII recipient')
+        ->and(fn () => app(EmailSendService::class)->send($project, $source, [
+            'from' => 'Larasend <receipts@example.com>',
+            'to' => ['Blocked < ÄBC@EXAMPLE.COM >'],
+            'subject' => 'ASCII case and space variant',
+            'html' => '<h1>Hello</h1>',
+            'text' => 'Hello',
+        ]))->toThrow(ValidationException::class);
 });
 
 it('allows sends to expired suppressions but blocks active suppressions', function () {

--- a/tests/Feature/ApiEmailTest.php
+++ b/tests/Feature/ApiEmailTest.php
@@ -257,6 +257,52 @@ it('blocks sends to suppressed recipients', function () {
     Queue::assertNothingPushed();
 });
 
+it('allows sends to expired suppressions but blocks active suppressions', function () {
+    [$workspace, $project, $source, $token] = larasendProjectFixture();
+
+    Queue::fake();
+
+    Suppression::create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'expired@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+        'expires_at' => now()->subMinute(),
+    ]);
+
+    $this->withToken($token)->postJson('/api/emails', [
+        'from' => 'Larasend <receipts@example.com>',
+        'to' => ['Expired <expired@example.com>'],
+        'subject' => 'Expired suppression',
+        'html' => '<h1>Hello</h1>',
+        'text' => 'Hello',
+    ])->assertAccepted();
+
+    Suppression::create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'active@example.com',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+        'expires_at' => now()->addMinute(),
+    ]);
+
+    $this->withToken($token)->postJson('/api/emails', [
+        'from' => 'Larasend <receipts@example.com>',
+        'to' => ['Active <active@example.com>'],
+        'subject' => 'Active suppression',
+        'html' => '<h1>Hello</h1>',
+        'text' => 'Hello',
+    ])->assertUnprocessable()
+        ->assertJsonValidationErrors('to');
+
+    expect(Email::query()->where('subject', 'Expired suppression')->exists())->toBeTrue()
+        ->and(Email::query()->where('subject', 'Active suppression')->exists())->toBeFalse();
+});
+
 it('lists and shows only emails scoped to the api key project', function () {
     [$workspace, $project, $source, $token] = larasendProjectFixture();
 

--- a/tests/Feature/CloudflareSuppressionSyncTest.php
+++ b/tests/Feature/CloudflareSuppressionSyncTest.php
@@ -160,6 +160,38 @@ it('preserves provider sync suppressions when the Cloudflare fetch fails', funct
     expect($suppression->fresh())->not->toBeNull();
 });
 
+it('preserves provider sync suppressions when Cloudflare returns an invalid success envelope', function (array $responseBody, string $slug) {
+    Http::preventStrayRequests();
+
+    [$project, $source] = cloudflareSuppressionSource($slug, "acc-{$slug}");
+
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'preserved@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+
+    Http::fake([
+        "https://api.cloudflare.com/client/v4/accounts/acc-{$slug}/email/sending/suppression*" => Http::response($responseBody),
+    ]);
+
+    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+
+    expect($suppression->fresh())->not->toBeNull();
+})->with([
+    'explicit API failure' => [
+        ['success' => false, 'result' => []],
+        'cf-envelope-failure',
+    ],
+    'missing result collection' => [
+        ['success' => true],
+        'cf-envelope-missing-result',
+    ],
+]);
+
 it('continues syncing other sources when one token fails', function () {
     cloudflareSuppressionSource('cf-bad', 'acc-bad');
     cloudflareSuppressionSource('cf-good', 'acc-good');

--- a/tests/Feature/CloudflareSuppressionSyncTest.php
+++ b/tests/Feature/CloudflareSuppressionSyncTest.php
@@ -7,6 +7,9 @@ use App\Models\Suppression;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\CloudflareApiClient;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Attributes\UniqueFor;
 use Illuminate\Support\Facades\Http;
 
 function cloudflareSuppressionSource(string $slug, string $accountId): array
@@ -41,6 +44,14 @@ it('pulls cloudflare suppressions into the project with mapped reasons', functio
                     ['id' => 'sup-2', 'email' => 'complainer@example.com', 'reason' => 'spam_complaint', 'created_at' => now()->toIso8601String(), 'expires_at' => now()->addMonth()->toIso8601String()],
                 ],
             ])
+            ->push(['success' => true, 'result' => []])
+            ->push([
+                'success' => true,
+                'result' => [
+                    ['id' => 'sup-1', 'email' => 'Bounced@Example.com', 'reason' => 'hard_bounce', 'created_at' => now()->toIso8601String(), 'expires_at' => null],
+                    ['id' => 'sup-2', 'email' => 'complainer@example.com', 'reason' => 'spam_complaint', 'created_at' => now()->toIso8601String(), 'expires_at' => now()->addMonth()->toIso8601String()],
+                ],
+            ])
             ->push(['success' => true, 'result' => []]),
     ]);
 
@@ -65,6 +76,20 @@ it('is idempotent across repeated sync runs', function () {
 
     Http::fake([
         'https://api.cloudflare.com/client/v4/accounts/acc-idem/email/sending/suppression*' => Http::sequence()
+            ->push([
+                'success' => true,
+                'result' => [
+                    ['id' => 'sup-1', 'email' => 'repeat@example.com', 'reason' => 'hard_bounce', 'created_at' => now()->toIso8601String(), 'expires_at' => null],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []])
+            ->push([
+                'success' => true,
+                'result' => [
+                    ['id' => 'sup-1', 'email' => 'repeat@example.com', 'reason' => 'hard_bounce', 'created_at' => now()->toIso8601String(), 'expires_at' => null],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []])
             ->push([
                 'success' => true,
                 'result' => [
@@ -208,10 +233,121 @@ it('continues syncing other sources when one token fails', function () {
                     ['id' => 'sup-9', 'email' => 'survivor@example.com', 'reason' => 'hard_bounce', 'created_at' => now()->toIso8601String(), 'expires_at' => null],
                 ],
             ])
+            ->push(['success' => true, 'result' => []])
+            ->push([
+                'success' => true,
+                'result' => [
+                    ['id' => 'sup-9', 'email' => 'survivor@example.com', 'reason' => 'hard_bounce', 'created_at' => now()->toIso8601String(), 'expires_at' => null],
+                ],
+            ])
             ->push(['success' => true, 'result' => []]),
     ]);
 
     (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
 
     expect(Suppression::query()->where('email', 'survivor@example.com')->exists())->toBeTrue();
+});
+
+it('does not prune local rows when complete Cloudflare snapshots keep changing', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-unstable', 'acc-unstable');
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'must-stay@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+    $snapshot = fn (string $id): array => [
+        'success' => true,
+        'result' => [[
+            'id' => $id,
+            'email' => "{$id}@example.com",
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
+    ];
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-unstable/email/sending/suppression*' => Http::sequence()
+            ->push($snapshot('first'))
+            ->push(['success' => true, 'result' => []])
+            ->push($snapshot('second'))
+            ->push(['success' => true, 'result' => []])
+            ->push($snapshot('third'))
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+
+    $this->assertModelExists($suppression);
+});
+
+it('never takes ownership of a colliding suppression or prunes it later', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-collision', 'acc-collision');
+    $sesSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Historical SES source',
+        'environment' => 'staging',
+        'provider' => 'ses',
+        'webhook_token' => 'token-'.str()->random(8),
+    ]);
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'email' => 'collision@example.com',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+    ]);
+    $present = [
+        'success' => true,
+        'result' => [[
+            'id' => 'cf-collision',
+            'email' => 'collision@example.com',
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
+    ];
+    $empty = ['success' => true, 'result' => []];
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-collision/email/sending/suppression*' => Http::sequence()
+            ->push($present)
+            ->push($empty)
+            ->push($present)
+            ->push($empty)
+            ->push($empty)
+            ->push($empty),
+    ]);
+
+    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+
+    expect($suppression->fresh())
+        ->not->toBeNull()
+        ->source_id->toBe($sesSource->id)
+        ->event_type->toBe('complaint')
+        ->reason->toBe('complaint');
+});
+
+it('has bounded unique execution and a non-overlapping schedule', function () {
+    $job = new SyncCloudflareSuppressions;
+    $event = collect(app(Schedule::class)->events())
+        ->first(fn ($event): bool => $event->description === SyncCloudflareSuppressions::class);
+    $uniqueFor = (new ReflectionClass($job))
+        ->getAttributes(UniqueFor::class)[0]
+        ->newInstance()
+        ->uniqueFor;
+    $retryAfterValues = collect(config('queue.connections'))
+        ->pluck('retry_after')
+        ->filter(fn ($retryAfter): bool => is_int($retryAfter));
+
+    expect($job)->toBeInstanceOf(ShouldBeUnique::class)
+        ->and($retryAfterValues->every(fn (int $retryAfter): bool => $job->timeout < $retryAfter))->toBeTrue()
+        ->and($uniqueFor)->toBeGreaterThan(3600 + $job->timeout)
+        ->and($event)->not->toBeNull()
+        ->and($event->withoutOverlapping)->toBeTrue();
 });

--- a/tests/Feature/CloudflareSuppressionSyncTest.php
+++ b/tests/Feature/CloudflareSuppressionSyncTest.php
@@ -87,6 +87,79 @@ it('is idempotent across repeated sync runs', function () {
     expect(Suppression::query()->where('email', 'repeat@example.com')->count())->toBe(1);
 });
 
+it('prunes missing provider sync suppressions only for the successfully fetched source', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-prune', 'acc-prune');
+    $otherSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Historical source',
+        'environment' => 'staging',
+        'provider' => 'ses',
+        'webhook_token' => 'token-'.str()->random(8),
+    ]);
+
+    $missingUpstream = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'missing-upstream@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+    $otherSourceSuppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $otherSource->id,
+        'email' => 'other-source@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+    $localSuppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'local-event@example.com',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+    ]);
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-prune/email/sending/suppression*' => Http::response([
+            'success' => true,
+            'result' => [],
+        ]),
+    ]);
+
+    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+
+    expect($missingUpstream->fresh())->toBeNull()
+        ->and($otherSourceSuppression->fresh())->not->toBeNull()
+        ->and($localSuppression->fresh())->not->toBeNull();
+});
+
+it('preserves provider sync suppressions when the Cloudflare fetch fails', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-preserve', 'acc-preserve');
+
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'still-suppressed@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-preserve/email/sending/suppression*' => Http::response([
+            'success' => false,
+            'errors' => [['code' => 10001, 'message' => 'invalid token']],
+        ], 401),
+    ]);
+
+    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+
+    expect($suppression->fresh())->not->toBeNull();
+});
+
 it('continues syncing other sources when one token fails', function () {
     cloudflareSuppressionSource('cf-bad', 'acc-bad');
     cloudflareSuppressionSource('cf-good', 'acc-good');

--- a/tests/Feature/CloudflareSuppressionSyncTest.php
+++ b/tests/Feature/CloudflareSuppressionSyncTest.php
@@ -520,8 +520,8 @@ it('does not prune when the source job exhausts its total work budget', function
     $this->assertModelExists($suppression);
 });
 
-it('aborts a suppression snapshot that exceeds the safe page limit', function () {
-    [, $source] = cloudflareSuppressionSource('cf-page-limit', 'acc-page-limit');
+it('completes a suppression list on a partial one hundredth data page', function () {
+    [, $source] = cloudflareSuppressionSource('cf-partial-page-limit', 'acc-partial-page-limit');
     $fullPage = [
         'success' => true,
         'result' => collect(range(1, 100))
@@ -536,18 +536,112 @@ it('aborts a suppression snapshot that exceeds the safe page limit', function ()
     ];
     $sequence = Http::sequence();
 
-    foreach (range(1, CloudflareApiClient::SUPPRESSION_MAX_PAGES_PER_SNAPSHOT) as $page) {
+    foreach (range(1, 99) as $page) {
         $sequence->push($fullPage);
     }
 
-    Http::fake([
-        'https://api.cloudflare.com/client/v4/accounts/acc-page-limit/email/sending/suppression*' => $sequence,
+    $sequence->push([
+        'success' => true,
+        'result' => [[
+            'id' => 'last-partial',
+            'email' => 'last-partial@example.com',
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
     ]);
 
-    expect(fn () => app(CloudflareApiClient::class)->listStableSuppressions($source, 60))
-        ->toThrow(RuntimeException::class, 'safe page limit');
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-partial-page-limit/email/sending/suppression*' => $sequence,
+    ]);
 
-    Http::assertSentCount(CloudflareApiClient::SUPPRESSION_MAX_PAGES_PER_SNAPSHOT);
+    $suppressions = app(CloudflareApiClient::class)->listSuppressions($source);
+
+    expect($suppressions)->toHaveCount(9901)
+        ->and($suppressions[9900]['email'])->toBe('last-partial@example.com');
+
+    Http::assertSentCount(100);
+});
+
+it('allows a terminal empty request after one hundred full data pages', function () {
+    [, $source] = cloudflareSuppressionSource('cf-terminal-page', 'acc-terminal-page');
+    $fullPage = [
+        'success' => true,
+        'result' => collect(range(1, 100))
+            ->map(fn (int $index): array => [
+                'id' => "suppression-{$index}",
+                'email' => "recipient-{$index}@example.com",
+                'reason' => 'hard_bounce',
+                'created_at' => now()->toIso8601String(),
+                'expires_at' => null,
+            ])
+            ->all(),
+    ];
+    $sequence = Http::sequence();
+
+    foreach (range(1, 100) as $page) {
+        $sequence->push($fullPage);
+    }
+
+    $sequence->push(['success' => true, 'result' => []]);
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-terminal-page/email/sending/suppression*' => $sequence,
+    ]);
+
+    expect(app(CloudflareApiClient::class)->listSuppressions($source))->toHaveCount(10000);
+
+    Http::assertSentCount(101);
+});
+
+it('rejects a true one hundred and first data page without pruning', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-overflow-page', 'acc-overflow-page');
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'overflow-preserved@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+    $fullPage = [
+        'success' => true,
+        'result' => collect(range(1, 100))
+            ->map(fn (int $index): array => [
+                'id' => "suppression-{$index}",
+                'email' => "recipient-{$index}@example.com",
+                'reason' => 'hard_bounce',
+                'created_at' => now()->toIso8601String(),
+                'expires_at' => null,
+            ])
+            ->all(),
+    ];
+    $sequence = Http::sequence();
+
+    foreach (range(1, 100) as $page) {
+        $sequence->push($fullPage);
+    }
+
+    $sequence->push([
+        'success' => true,
+        'result' => [[
+            'id' => 'overflow',
+            'email' => 'overflow@example.com',
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
+    ]);
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-overflow-page/email/sending/suppression*' => $sequence,
+    ]);
+
+    expect(fn () => runCloudflareSuppressionSourceSync($source))
+        ->toThrow(RuntimeException::class, 'data page limit');
+
+    Http::assertSentCount(101);
+    $this->assertModelExists($suppression);
 });
 
 it('has bounded unique source execution and a non-overlapping dispatcher schedule', function () {

--- a/tests/Feature/CloudflareSuppressionSyncTest.php
+++ b/tests/Feature/CloudflareSuppressionSyncTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Jobs\SyncCloudflareSourceSuppressions;
 use App\Jobs\SyncCloudflareSuppressions;
+use App\Models\ApiKey;
+use App\Models\Email;
 use App\Models\Project;
 use App\Models\Source;
 use App\Models\Suppression;
@@ -11,6 +14,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Queue\Attributes\UniqueFor;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 
 function cloudflareSuppressionSource(string $slug, string $accountId): array
 {
@@ -30,6 +34,12 @@ function cloudflareSuppressionSource(string $slug, string $accountId): array
     ]);
 
     return [$project, $source];
+}
+
+function runCloudflareSuppressionSourceSync(Source $source, ?CloudflareApiClient $cloudflare = null): void
+{
+    (new SyncCloudflareSourceSuppressions($source->id))
+        ->handle($cloudflare ?? app(CloudflareApiClient::class));
 }
 
 it('pulls cloudflare suppressions into the project with mapped reasons', function () {
@@ -55,7 +65,7 @@ it('pulls cloudflare suppressions into the project with mapped reasons', functio
             ->push(['success' => true, 'result' => []]),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    runCloudflareSuppressionSourceSync($source);
 
     $bounced = Suppression::query()->where('email', 'bounced@example.com')->firstOrFail();
     $complained = Suppression::query()->where('email', 'complainer@example.com')->firstOrFail();
@@ -72,7 +82,7 @@ it('pulls cloudflare suppressions into the project with mapped reasons', functio
 });
 
 it('is idempotent across repeated sync runs', function () {
-    cloudflareSuppressionSource('cf-idem', 'acc-idem');
+    [, $source] = cloudflareSuppressionSource('cf-idem', 'acc-idem');
 
     Http::fake([
         'https://api.cloudflare.com/client/v4/accounts/acc-idem/email/sending/suppression*' => Http::sequence()
@@ -106,8 +116,8 @@ it('is idempotent across repeated sync runs', function () {
             ->push(['success' => true, 'result' => []]),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    runCloudflareSuppressionSourceSync($source);
+    runCloudflareSuppressionSourceSync($source);
 
     expect(Suppression::query()->where('email', 'repeat@example.com')->count())->toBe(1);
 });
@@ -154,7 +164,7 @@ it('prunes missing provider sync suppressions only for the successfully fetched 
         ]),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    runCloudflareSuppressionSourceSync($source);
 
     expect($missingUpstream->fresh())->toBeNull()
         ->and($otherSourceSuppression->fresh())->not->toBeNull()
@@ -180,7 +190,8 @@ it('preserves provider sync suppressions when the Cloudflare fetch fails', funct
         ], 401),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    expect(fn () => runCloudflareSuppressionSourceSync($source))
+        ->toThrow(RuntimeException::class);
 
     expect($suppression->fresh())->not->toBeNull();
 });
@@ -203,7 +214,8 @@ it('preserves provider sync suppressions when Cloudflare returns an invalid succ
         "https://api.cloudflare.com/client/v4/accounts/acc-{$slug}/email/sending/suppression*" => Http::response($responseBody),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    expect(fn () => runCloudflareSuppressionSourceSync($source))
+        ->toThrow(RuntimeException::class);
 
     expect($suppression->fresh())->not->toBeNull();
 })->with([
@@ -217,9 +229,9 @@ it('preserves provider sync suppressions when Cloudflare returns an invalid succ
     ],
 ]);
 
-it('continues syncing other sources when one token fails', function () {
-    cloudflareSuppressionSource('cf-bad', 'acc-bad');
-    cloudflareSuppressionSource('cf-good', 'acc-good');
+it('isolates source failures into separate jobs', function () {
+    [, $badSource] = cloudflareSuppressionSource('cf-bad', 'acc-bad');
+    [, $goodSource] = cloudflareSuppressionSource('cf-good', 'acc-good');
 
     Http::fake([
         'https://api.cloudflare.com/client/v4/accounts/acc-bad/email/sending/suppression*' => Http::response([
@@ -243,7 +255,10 @@ it('continues syncing other sources when one token fails', function () {
             ->push(['success' => true, 'result' => []]),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    expect(fn () => runCloudflareSuppressionSourceSync($badSource))
+        ->toThrow(RuntimeException::class);
+
+    runCloudflareSuppressionSourceSync($goodSource);
 
     expect(Suppression::query()->where('email', 'survivor@example.com')->exists())->toBeTrue();
 });
@@ -279,12 +294,13 @@ it('does not prune local rows when complete Cloudflare snapshots keep changing',
             ->push(['success' => true, 'result' => []]),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    expect(fn () => runCloudflareSuppressionSourceSync($source))
+        ->toThrow(RuntimeException::class);
 
     $this->assertModelExists($suppression);
 });
 
-it('never takes ownership of a colliding suppression or prunes it later', function () {
+it('preserves an active colliding suppression and never prunes it later', function () {
     [$project, $source] = cloudflareSuppressionSource('cf-collision', 'acc-collision');
     $sesSource = Source::create([
         'project_id' => $project->id,
@@ -323,8 +339,8 @@ it('never takes ownership of a colliding suppression or prunes it later', functi
             ->push($empty),
     ]);
 
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
-    (new SyncCloudflareSuppressions)->handle(app(CloudflareApiClient::class));
+    runCloudflareSuppressionSourceSync($source);
+    runCloudflareSuppressionSourceSync($source);
 
     expect($suppression->fresh())
         ->not->toBeNull()
@@ -333,11 +349,219 @@ it('never takes ownership of a colliding suppression or prunes it later', functi
         ->reason->toBe('complaint');
 });
 
-it('has bounded unique execution and a non-overlapping schedule', function () {
-    $job = new SyncCloudflareSuppressions;
+it('reactivates an expired collision as Cloudflare-owned, blocks sending, and safely prunes stable absence', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-expired-collision', 'acc-expired-collision');
+    $historicalSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Historical SES source',
+        'environment' => 'staging',
+        'provider' => 'ses',
+        'default_from_email' => 'receipts@example.com',
+        'aws_access_key_id' => 'test-access-key',
+        'aws_secret_access_key' => 'test-secret-key',
+        'last_quota' => [
+            'Max24HourSend' => 50000,
+            'MaxSendRate' => 200,
+            'SentLast24Hours' => 25,
+        ],
+        'last_quota_checked_at' => now(),
+        'webhook_token' => 'token-'.str()->random(8),
+    ]);
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $historicalSource->id,
+        'email' => 'expired-collision@example.com',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+        'expires_at' => now()->subMinute(),
+    ]);
+    $present = [
+        'success' => true,
+        'result' => [[
+            'id' => 'cf-expired-collision',
+            'email' => 'expired-collision@example.com',
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
+    ];
+    $empty = ['success' => true, 'result' => []];
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-expired-collision/email/sending/suppression*' => Http::sequence()
+            ->push($present)
+            ->push($empty)
+            ->push($present)
+            ->push($empty)
+            ->push($empty)
+            ->push($empty),
+    ]);
+
+    runCloudflareSuppressionSourceSync($source);
+
+    Http::assertSentCount(4);
+
+    expect($suppression->fresh())
+        ->source_id->toBe($source->id)
+        ->event_type->toBe('provider_sync')
+        ->reason->toBe('hard_bounce')
+        ->expires_at->toBeNull()
+        ->and($project->suppressions()->active()->whereKey($suppression->id)->exists())->toBeTrue();
+
+    $project->domains()->create([
+        'domain' => 'example.com',
+        'status' => 'verified',
+        'dns_records' => [],
+        'verified_at' => now(),
+    ]);
+    $issued = ApiKey::issue($project, 'Collision test', $historicalSource);
+    Queue::fake();
+
+    $this->withToken($issued['plain_text'])->postJson('/api/emails', [
+        'from' => 'Larasend <receipts@example.com>',
+        'to' => ['Expired Collision <expired-collision@example.com>'],
+        'subject' => 'Must stay blocked',
+        'html' => '<h1>Blocked</h1>',
+        'text' => 'Blocked',
+    ])->assertUnprocessable()
+        ->assertJsonValidationErrors('to');
+
+    expect(Email::query()->where('subject', 'Must stay blocked')->exists())->toBeFalse();
+
+    runCloudflareSuppressionSourceSync($source);
+
+    expect($suppression->fresh())->toBeNull();
+});
+
+it('fans out a bounded page of unique source jobs and continues with a cursor', function () {
+    Queue::fake();
+
+    $sources = collect(range(1, SyncCloudflareSuppressions::BATCH_SIZE + 1))
+        ->map(fn (int $index): Source => cloudflareSuppressionSource(
+            "cf-fanout-{$index}",
+            "acc-fanout-{$index}",
+        )[1]);
+
+    (new SyncCloudflareSuppressions)->handle();
+
+    Queue::assertPushed(SyncCloudflareSourceSuppressions::class, SyncCloudflareSuppressions::BATCH_SIZE);
+    Queue::assertPushed(
+        SyncCloudflareSuppressions::class,
+        fn (SyncCloudflareSuppressions $job): bool => $job->afterSourceId === $sources[SyncCloudflareSuppressions::BATCH_SIZE - 1]->id,
+    );
+});
+
+it('does not prune when the stable snapshot exceeds its wall clock budget', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-deadline', 'acc-deadline');
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'deadline-preserved@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+    $cloudflare = new class extends CloudflareApiClient
+    {
+        /** @var array<int, float> */
+        private array $times = [0.0, 0.0, 61.0];
+
+        protected function monotonicTime(): float
+        {
+            return array_shift($this->times) ?? 61.0;
+        }
+    };
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-deadline/email/sending/suppression*' => Http::response([
+            'success' => true,
+            'result' => [],
+        ]),
+    ]);
+
+    expect(fn () => runCloudflareSuppressionSourceSync($source, $cloudflare))
+        ->toThrow(RuntimeException::class, 'time budget');
+
+    $this->assertModelExists($suppression);
+});
+
+it('does not prune when the source job exhausts its total work budget', function () {
+    [$project, $source] = cloudflareSuppressionSource('cf-work-budget', 'acc-work-budget');
+    $suppression = Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email' => 'work-budget-preserved@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+    ]);
+    $job = new class($source->id) extends SyncCloudflareSourceSuppressions
+    {
+        /** @var array<int, float> */
+        private array $times = [0.0, 71.0];
+
+        protected function monotonicTime(): float
+        {
+            return array_shift($this->times) ?? 71.0;
+        }
+    };
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-work-budget/email/sending/suppression*' => Http::response([
+            'success' => true,
+            'result' => [],
+        ]),
+    ]);
+
+    expect(fn () => $job->handle(app(CloudflareApiClient::class)))
+        ->toThrow(RuntimeException::class, 'work budget');
+
+    $this->assertModelExists($suppression);
+});
+
+it('aborts a suppression snapshot that exceeds the safe page limit', function () {
+    [, $source] = cloudflareSuppressionSource('cf-page-limit', 'acc-page-limit');
+    $fullPage = [
+        'success' => true,
+        'result' => collect(range(1, 100))
+            ->map(fn (int $index): array => [
+                'id' => "suppression-{$index}",
+                'email' => "recipient-{$index}@example.com",
+                'reason' => 'hard_bounce',
+                'created_at' => now()->toIso8601String(),
+                'expires_at' => null,
+            ])
+            ->all(),
+    ];
+    $sequence = Http::sequence();
+
+    foreach (range(1, CloudflareApiClient::SUPPRESSION_MAX_PAGES_PER_SNAPSHOT) as $page) {
+        $sequence->push($fullPage);
+    }
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/acc-page-limit/email/sending/suppression*' => $sequence,
+    ]);
+
+    expect(fn () => app(CloudflareApiClient::class)->listStableSuppressions($source, 60))
+        ->toThrow(RuntimeException::class, 'safe page limit');
+
+    Http::assertSentCount(CloudflareApiClient::SUPPRESSION_MAX_PAGES_PER_SNAPSHOT);
+});
+
+it('has bounded unique source execution and a non-overlapping dispatcher schedule', function () {
+    [, $firstSource] = cloudflareSuppressionSource('cf-unique-a', 'acc-unique-a');
+    [, $secondSource] = cloudflareSuppressionSource('cf-unique-b', 'acc-unique-b');
+    $dispatcher = new SyncCloudflareSuppressions;
+    $sourceJob = new SyncCloudflareSourceSuppressions($firstSource->id);
     $event = collect(app(Schedule::class)->events())
         ->first(fn ($event): bool => $event->description === SyncCloudflareSuppressions::class);
-    $uniqueFor = (new ReflectionClass($job))
+    $dispatcherUniqueFor = (new ReflectionClass($dispatcher))
+        ->getAttributes(UniqueFor::class)[0]
+        ->newInstance()
+        ->uniqueFor;
+    $sourceUniqueFor = (new ReflectionClass($sourceJob))
         ->getAttributes(UniqueFor::class)[0]
         ->newInstance()
         ->uniqueFor;
@@ -345,9 +569,15 @@ it('has bounded unique execution and a non-overlapping schedule', function () {
         ->pluck('retry_after')
         ->filter(fn ($retryAfter): bool => is_int($retryAfter));
 
-    expect($job)->toBeInstanceOf(ShouldBeUnique::class)
-        ->and($retryAfterValues->every(fn (int $retryAfter): bool => $job->timeout < $retryAfter))->toBeTrue()
-        ->and($uniqueFor)->toBeGreaterThan(3600 + $job->timeout)
+    expect($dispatcher)->toBeInstanceOf(ShouldBeUnique::class)
+        ->and($sourceJob)->toBeInstanceOf(ShouldBeUnique::class)
+        ->and($sourceJob->uniqueId())->not->toBe((new SyncCloudflareSourceSuppressions($secondSource->id))->uniqueId())
+        ->and(SyncCloudflareSourceSuppressions::SNAPSHOT_BUDGET_SECONDS)->toBeLessThan(SyncCloudflareSourceSuppressions::WORK_BUDGET_SECONDS)
+        ->and(SyncCloudflareSourceSuppressions::WORK_BUDGET_SECONDS)->toBeLessThan($sourceJob->timeout)
+        ->and($retryAfterValues->every(fn (int $retryAfter): bool => $dispatcher->timeout < $retryAfter))->toBeTrue()
+        ->and($retryAfterValues->every(fn (int $retryAfter): bool => $sourceJob->timeout < $retryAfter))->toBeTrue()
+        ->and($dispatcherUniqueFor)->toBeGreaterThan(3600 + $dispatcher->timeout)
+        ->and($sourceUniqueFor)->toBeGreaterThan(3600 + $sourceJob->timeout)
         ->and($event)->not->toBeNull()
         ->and($event->withoutOverlapping)->toBeTrue();
 });

--- a/tests/Feature/DashboardActionsTest.php
+++ b/tests/Feature/DashboardActionsTest.php
@@ -402,6 +402,27 @@ it('deletes project scoped api keys from the dashboard', function () {
     expect($apiKey->fresh())->toBeNull();
 });
 
+it('preserves exact api key scopes when rotating keys', function (?array $scopes, bool $allowsSuppressionManagement) {
+    $user = User::factory()->create();
+    $project = app(ProjectContext::class)->projectFor($user);
+    $apiKey = ApiKey::issue($project, 'Production key')['api_key'];
+    $apiKey->forceFill(['scopes' => $scopes])->save();
+
+    $this->actingAs($user)
+        ->post("/api-keys/{$apiKey->id}/rotate")
+        ->assertRedirect('/api-keys');
+
+    $rotated = $project->apiKeys()->whereKeyNot($apiKey->id)->firstOrFail();
+
+    expect($apiKey->fresh())->toBeNull()
+        ->and($rotated->scopes)->toBe($scopes)
+        ->and($rotated->allows('manage:suppressions'))->toBe($allowsSuppressionManagement);
+})->with([
+    'legacy full access' => [null, true],
+    'explicit deny all' => [[], false],
+    'explicit scopes' => [['read:activity', 'manage:suppressions'], true],
+]);
+
 it('syncs ses source quota from aws', function () {
     $user = User::factory()->create();
     $project = app(ProjectContext::class)->projectFor($user);

--- a/tests/Feature/SesWebhookTest.php
+++ b/tests/Feature/SesWebhookTest.php
@@ -7,6 +7,8 @@ use App\Models\Suppression;
 use App\Models\User;
 use App\Models\WebhookLog;
 use App\Models\Workspace;
+use App\Services\SesEventNormalizer;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 
 function sesWebhookFixture(): array
@@ -171,4 +173,71 @@ it('records suppressions for permanent ses bounces and complaints', function () 
     expect(Suppression::query()->where('email', 'maya@example.com')->where('reason', 'hard_bounce')->exists())->toBeTrue()
         ->and(Suppression::query()->where('email', 'abuse@example.com')->where('reason', 'complaint')->exists())->toBeTrue()
         ->and($email->fresh()->status)->toBe('complained');
+});
+
+it('atomically replaces Cloudflare ownership when recording an SES complaint', function () {
+    [$source, $email] = sesWebhookFixture();
+    $cloudflareSource = Source::create([
+        'project_id' => $email->project_id,
+        'name' => 'Cloudflare',
+        'environment' => 'staging',
+        'provider' => 'cloudflare',
+        'cloudflare_api_token' => 'token',
+        'cloudflare_account_id' => 'account',
+        'webhook_token' => 'cloudflare-webhook-token',
+    ]);
+    $suppression = Suppression::create([
+        'workspace_id' => $email->workspace_id,
+        'project_id' => $email->project_id,
+        'source_id' => $cloudflareSource->id,
+        'email' => 'abuse@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+        'expires_at' => now()->addDay(),
+    ]);
+    $suppression->forceFill([
+        'created_at' => now()->subDay(),
+        'updated_at' => now()->subDay(),
+    ])->saveQuietly();
+    $originalCreatedAt = $suppression->created_at;
+    $payload = [
+        'eventType' => 'Complaint',
+        'mail' => [
+            'messageId' => 'ses-1',
+            'timestamp' => now()->toIso8601String(),
+            'destination' => ['Abuse@Example.com'],
+        ],
+        'complaint' => [
+            'timestamp' => now()->toIso8601String(),
+            'complainedRecipients' => [
+                ['emailAddress' => 'Abuse@Example.com'],
+            ],
+        ],
+    ];
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    app(SesEventNormalizer::class)->record($source, $payload);
+
+    $suppressionQueries = collect(DB::getQueryLog())
+        ->pluck('query')
+        ->filter(fn (string $query): bool => str_contains(strtolower($query), 'suppressions'))
+        ->values();
+    DB::disableQueryLog();
+
+    expect($suppression->fresh())
+        ->id->toBe($suppression->id)
+        ->workspace_id->toBe($email->workspace_id)
+        ->project_id->toBe($email->project_id)
+        ->source_id->toBe($source->id)
+        ->email_id->toBe($email->id)
+        ->email->toBe('abuse@example.com')
+        ->reason->toBe('complaint')
+        ->event_type->toBe('complaint')
+        ->expires_at->toBeNull()
+        ->created_at->toEqual($originalCreatedAt)
+        ->updated_at->toBeGreaterThan($originalCreatedAt)
+        ->and($suppressionQueries)->toHaveCount(1)
+        ->and($suppressionQueries->sole())->toMatch('/on conflict|on duplicate key update/i');
 });

--- a/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
+++ b/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use App\Models\Email;
+use App\Models\Project;
+use App\Models\Source;
+use App\Models\Suppression;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\SesEventNormalizer;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+function suppressionEmailNormalizationMigration(): Migration
+{
+    $migrationFiles = glob(database_path('migrations/*_normalize_suppression_emails_and_enforce_unique_index.php'));
+
+    expect($migrationFiles)->toHaveCount(1);
+
+    return require $migrationFiles[0];
+}
+
+it('safely consolidates historical case variants and enforces normalized uniqueness', function () {
+    $migration = suppressionEmailNormalizationMigration();
+    $migration->down();
+
+    $now = Carbon::parse('2026-07-24 12:00:00');
+    $this->travelTo($now);
+
+    $user = User::factory()->create();
+    $workspace = Workspace::create([
+        'owner_id' => $user->id,
+        'name' => 'Suppression Migration',
+        'slug' => 'suppression-migration',
+    ]);
+    $project = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Suppression Migration',
+        'slug' => 'suppression-migration',
+    ]);
+    $sesSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'SES',
+        'environment' => 'prod',
+        'provider' => 'ses',
+        'webhook_token' => 'ses-suppression-migration',
+    ]);
+    $cloudflareSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Cloudflare',
+        'environment' => 'staging',
+        'provider' => 'cloudflare',
+        'cloudflare_api_token' => 'token',
+        'cloudflare_account_id' => 'account',
+        'webhook_token' => 'cloudflare-suppression-migration',
+    ]);
+    $historicalEmail = Email::create([
+        'public_id' => 'historical_suppression_email',
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'status' => 'complained',
+        'ses_message_id' => 'ses-historical',
+        'from_email' => 'receipts@example.com',
+        'subject' => 'Historical complaint',
+    ]);
+    $incomingEmail = Email::create([
+        'public_id' => 'incoming_suppression_email',
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'status' => 'sent',
+        'ses_message_id' => 'ses-incoming',
+        'from_email' => 'receipts@example.com',
+        'subject' => 'Incoming complaint',
+    ]);
+
+    $complaintId = DB::table('suppressions')->insertGetId([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'email_id' => $historicalEmail->id,
+        'email' => ' Abuse@Example.com ',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+        'expires_at' => $now->copy()->addWeek(),
+        'created_at' => $now->copy()->subDays(3),
+        'updated_at' => $now->copy()->subDays(2),
+    ]);
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $cloudflareSource->id,
+        'email_id' => null,
+        'email' => 'abuse@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+        'expires_at' => null,
+        'created_at' => $now->copy()->subDays(2),
+        'updated_at' => $now->copy()->subDay(),
+    ]);
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'email_id' => $historicalEmail->id,
+        'email' => 'ABUSE@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+        'expires_at' => $now->copy()->subDay(),
+        'created_at' => $now->copy()->subDays(4),
+        'updated_at' => $now,
+    ]);
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'email_id' => null,
+        'email' => ' Singleton@Example.com ',
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+        'expires_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $migration->up();
+
+    $suppression = Suppression::query()
+        ->where('project_id', $project->id)
+        ->where('email', 'abuse@example.com')
+        ->firstOrFail();
+
+    expect($suppression)
+        ->id->toBe($complaintId)
+        ->source_id->toBe($sesSource->id)
+        ->email_id->toBe($historicalEmail->id)
+        ->reason->toBe('complaint')
+        ->event_type->toBe('complaint')
+        ->expires_at->toBeNull()
+        ->and(Suppression::query()->where('project_id', $project->id)->where('email', 'abuse@example.com')->count())->toBe(1)
+        ->and(Suppression::query()->where('project_id', $project->id)->where('email', 'singleton@example.com')->exists())->toBeTrue();
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    app(SesEventNormalizer::class)->record($sesSource, [
+        'eventType' => 'Complaint',
+        'mail' => [
+            'messageId' => 'ses-incoming',
+            'timestamp' => $now->toIso8601String(),
+            'destination' => ['AbUsE@Example.com'],
+        ],
+        'complaint' => [
+            'timestamp' => $now->toIso8601String(),
+            'complainedRecipients' => [
+                ['emailAddress' => 'AbUsE@Example.com'],
+            ],
+        ],
+    ]);
+
+    $suppressionQueries = collect(DB::getQueryLog())
+        ->pluck('query')
+        ->filter(fn (string $query): bool => str_contains(strtolower($query), 'suppressions'))
+        ->values();
+    DB::disableQueryLog();
+
+    expect($suppression->fresh())
+        ->id->toBe($complaintId)
+        ->source_id->toBe($sesSource->id)
+        ->email_id->toBe($incomingEmail->id)
+        ->email->toBe('abuse@example.com')
+        ->reason->toBe('complaint')
+        ->event_type->toBe('complaint')
+        ->expires_at->toBeNull()
+        ->and(Suppression::query()->where('project_id', $project->id)->where('email', 'abuse@example.com')->count())->toBe(1)
+        ->and($suppressionQueries)->toHaveCount(1)
+        ->and($suppressionQueries->sole())->toMatch('/on conflict|on duplicate key update/i');
+
+    $normalizedByModel = Suppression::create([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'email' => ' Model.Write@Example.com ',
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+    ]);
+
+    expect($normalizedByModel->email)->toBe('model.write@example.com');
+
+    expect(fn () => DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $cloudflareSource->id,
+        'email_id' => null,
+        'email' => 'ABUSE@EXAMPLE.COM',
+        'reason' => 'hard_bounce',
+        'event_type' => 'provider_sync',
+        'expires_at' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]))->toThrow(QueryException::class);
+});

--- a/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
+++ b/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
@@ -1,24 +1,32 @@
 <?php
 
+use App\Jobs\SyncCloudflareSourceSuppressions;
 use App\Models\Email;
 use App\Models\Project;
 use App\Models\Source;
 use App\Models\Suppression;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Services\CloudflareApiClient;
 use App\Services\SesEventNormalizer;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 
-function suppressionEmailNormalizationMigration(): Migration
+function suppressionEmailNormalizationMigrationFile(): string
 {
     $migrationFiles = glob(database_path('migrations/*_normalize_suppression_emails_and_enforce_unique_index.php'));
 
     expect($migrationFiles)->toHaveCount(1);
 
-    return require $migrationFiles[0];
+    return $migrationFiles[0];
+}
+
+function suppressionEmailNormalizationMigration(): Migration
+{
+    return require suppressionEmailNormalizationMigrationFile();
 }
 
 it('safely consolidates historical case variants and enforces normalized uniqueness', function () {
@@ -201,4 +209,189 @@ it('safely consolidates historical case variants and enforces normalized uniquen
         'created_at' => $now,
         'updated_at' => $now,
     ]))->toThrow(QueryException::class);
+});
+
+it('keeps an active local blocker over a Cloudflare complaint and protects it from later pruning', function () {
+    $migration = suppressionEmailNormalizationMigration();
+    $migration->down();
+
+    $now = Carbon::parse('2026-07-24 12:00:00');
+    $this->travelTo($now);
+
+    $user = User::factory()->create();
+    $workspace = Workspace::create([
+        'owner_id' => $user->id,
+        'name' => 'Inverse Suppression Collision',
+        'slug' => 'inverse-suppression-collision',
+    ]);
+    $project = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Inverse Suppression Collision',
+        'slug' => 'inverse-suppression-collision',
+    ]);
+    $sesSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'SES',
+        'environment' => 'prod',
+        'provider' => 'ses',
+        'webhook_token' => 'ses-inverse-collision',
+    ]);
+    $cloudflareSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Cloudflare',
+        'environment' => 'staging',
+        'provider' => 'cloudflare',
+        'cloudflare_api_token' => 'token',
+        'cloudflare_account_id' => 'inverse-collision-account',
+        'webhook_token' => 'cloudflare-inverse-collision',
+    ]);
+
+    $localId = DB::table('suppressions')->insertGetId([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $sesSource->id,
+        'email_id' => null,
+        'email' => ' Independent@Example.com ',
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+        'expires_at' => $now->copy()->addWeek(),
+        'created_at' => $now->copy()->subDays(2),
+        'updated_at' => $now->copy()->subDay(),
+    ]);
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $cloudflareSource->id,
+        'email_id' => null,
+        'email' => 'independent@example.com',
+        'reason' => 'complaint',
+        'event_type' => 'provider_sync',
+        'expires_at' => null,
+        'created_at' => $now->copy()->subDay(),
+        'updated_at' => $now,
+    ]);
+
+    $migration->up();
+
+    $survivor = Suppression::query()
+        ->where('project_id', $project->id)
+        ->where('email', 'independent@example.com')
+        ->firstOrFail();
+
+    expect($survivor)
+        ->id->toBe($localId)
+        ->source_id->toBe($sesSource->id)
+        ->reason->toBe('hard_bounce')
+        ->event_type->toBe('bounce')
+        ->expires_at->toBeNull();
+
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/inverse-collision-account/email/sending/suppression*' => Http::sequence()
+            ->push(['success' => true, 'result' => []])
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    (new SyncCloudflareSourceSuppressions($cloudflareSource->id))
+        ->handle(app(CloudflareApiClient::class));
+
+    expect($survivor->fresh())
+        ->id->toBe($localId)
+        ->source_id->toBe($sesSource->id)
+        ->event_type->toBe('bounce');
+});
+
+it('uses the same ASCII normalization contract in the migration and model', function () {
+    $migration = suppressionEmailNormalizationMigration();
+    $migration->down();
+
+    $user = User::factory()->create();
+    $workspace = Workspace::create([
+        'owner_id' => $user->id,
+        'name' => 'Suppression Canonicalization',
+        'slug' => 'suppression-canonicalization',
+    ]);
+    $project = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Suppression Canonicalization',
+        'slug' => 'suppression-canonicalization',
+    ]);
+    $source = Source::create([
+        'project_id' => $project->id,
+        'name' => 'SES',
+        'environment' => 'prod',
+        'provider' => 'ses',
+        'webhook_token' => 'ses-suppression-canonicalization',
+    ]);
+
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email_id' => null,
+        'email' => "\tTabs@Example.com\t",
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+        'expires_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email_id' => null,
+        'email' => "\tÄBC@Unicode.Example\t",
+        'reason' => 'complaint',
+        'event_type' => 'complaint',
+        'expires_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $migration->up();
+
+    expect(DB::table('suppressions')->where('reason', 'hard_bounce')->value('email'))
+        ->toBe("\ttabs@example.com\t")
+        ->and(DB::table('suppressions')->where('reason', 'complaint')->value('email'))
+        ->toBe("\tÄbc@unicode.example\t");
+
+    $model = new Suppression;
+    $model->email = "\tTABS@Example.com\t";
+    $unicodeModel = new Suppression;
+    $unicodeModel->email = "\tÄBC@Unicode.Example\t";
+
+    expect($model->getAttributes()['email'])->toBe("\ttabs@example.com\t")
+        ->and($unicodeModel->getAttributes()['email'])->toBe("\tÄbc@unicode.example\t")
+        ->and(fn () => Suppression::create([
+            'workspace_id' => $workspace->id,
+            'project_id' => $project->id,
+            'source_id' => $source->id,
+            'email' => "\tTABS@Example.com\t",
+            'reason' => 'hard_bounce',
+            'event_type' => 'bounce',
+        ]))->toThrow(QueryException::class);
+
+    DB::table('suppressions')->insert([
+        'workspace_id' => $workspace->id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'email_id' => null,
+        'email' => 'tabs@example.com',
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+        'expires_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(Suppression::query()->where('project_id', $project->id)->count())->toBe(3);
+});
+
+it('locks affected duplicate rows before deleting a loser', function () {
+    $migrationSource = file_get_contents(suppressionEmailNormalizationMigrationFile());
+
+    expect($migrationSource)
+        ->toContain('->lockForUpdate()')
+        ->and($migrationSource)->toMatch('/lockForUpdate\\(\\).*whereIn\\([^;]+delete\\(\\)/s');
 });

--- a/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
+++ b/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
@@ -410,3 +410,96 @@ it('uses binary indexed values and replaces the conflicting legacy unique index 
         ->toContain('dropUnique(self::ORIGINAL_UNIQUE_INDEX)')
         ->toContain("unique(['project_id', 'email'], self::ORIGINAL_UNIQUE_INDEX)");
 });
+
+it('applies the SQL Server binary collation to the normalization input', function () {
+    $migrationSource = file_get_contents(suppressionEmailNormalizationMigrationFile());
+
+    expect($migrationSource)
+        ->toContain("'TRIM(email COLLATE Latin1_General_100_BIN2)'")
+        ->not->toContain("\$this->normalizedEmailExpression().' COLLATE Latin1_General_100_BIN2'")
+        ->toContain("'email_normalized'")
+        ->not->toContain("'normalized_email'");
+});
+
+it('routes every runtime suppression predicate through the driver normalized key', function () {
+    $modelSource = file_get_contents(app_path('Models/Suppression.php'));
+    $sendServiceSource = file_get_contents(app_path('Services/EmailSendService.php'));
+    $syncJobSource = file_get_contents(app_path('Jobs/SyncCloudflareSourceSuppressions.php'));
+    $sesNormalizerSource = file_get_contents(app_path('Services/SesEventNormalizer.php'));
+
+    $query = Suppression::query()->whereNormalizedEmailIn([
+        ' ASCII@Example.com ',
+        'ÄBC@Example.com',
+    ]);
+
+    expect($query->toSql())
+        ->toContain('"email" in (?, ?)')
+        ->and($query->getBindings())->toBe([
+            'ascii@example.com',
+            'Äbc@example.com',
+        ])
+        ->and($modelSource)
+        ->toContain("'email_normalized'")
+        ->toContain("'mysql', 'mariadb', 'sqlsrv'")
+        ->and($sendServiceSource)
+        ->toContain('->whereNormalizedEmailIn($recipients)')
+        ->not->toContain("->whereIn('email', \$recipients)")
+        ->and($syncJobSource)
+        ->toContain('->whereNormalizedEmail($email)')
+        ->toContain('->whereNormalizedEmailNotIn($syncedEmails)')
+        ->not->toContain("->whereNotIn('email', \$syncedEmails)")
+        ->and($sesNormalizerSource)
+        ->toContain('WITH (HOLDLOCK)')
+        ->toContain('[email_normalized]')
+        ->toMatch('/\\[target\\]\\.\\[project_id\\].*\\[target\\]\\.\\[email_normalized\\]/s');
+});
+
+it('preflights legacy collation conflicts without partially changing the schema', function () {
+    config()->set('database.connections.suppression_rollback_test', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'foreign_key_constraints' => true,
+    ]);
+
+    $connection = DB::connection('suppression_rollback_test');
+
+    try {
+        $connection->statement(
+            'CREATE TABLE suppressions ('
+            .'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+            .'project_id INTEGER NOT NULL, '
+            .'email TEXT COLLATE NOCASE NOT NULL, '
+            .'email_normalized TEXT'
+            .')',
+        );
+        $connection->table('suppressions')->insert([
+            ['project_id' => 7, 'email' => 'Case@Example.com'],
+            ['project_id' => 7, 'email' => 'case@example.com'],
+        ]);
+
+        $columnsBefore = $connection->getSchemaBuilder()->getColumnListing('suppressions');
+        $rowsBefore = $connection->table('suppressions')->orderBy('id')->get()->all();
+        $migration = suppressionEmailNormalizationMigration();
+        $preflight = new ReflectionMethod($migration, 'assertLegacyUniqueIndexCanBeRestored');
+
+        expect(fn () => $preflight->invoke($migration, $connection))
+            ->toThrow(RuntimeException::class, 'Legacy suppression uniqueness cannot be restored');
+
+        expect($connection->getSchemaBuilder()->getColumnListing('suppressions'))
+            ->toBe($columnsBefore)
+            ->and($connection->table('suppressions')->orderBy('id')->get()->all())
+            ->toEqual($rowsBefore);
+    } finally {
+        DB::purge('suppression_rollback_test');
+    }
+});
+
+it('runs the rollback conflict preflight before destructive driver DDL', function () {
+    $migrationSource = file_get_contents(suppressionEmailNormalizationMigrationFile());
+    $preflightPosition = strpos($migrationSource, '$this->assertLegacyUniqueIndexCanBeRestored');
+    $mysqlDdlPosition = strpos($migrationSource, "'ALTER TABLE `suppressions`'");
+
+    expect($preflightPosition)->not->toBeFalse()
+        ->and($mysqlDdlPosition)->not->toBeFalse()
+        ->and($preflightPosition)->toBeLessThan($mysqlDdlPosition);
+});

--- a/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
+++ b/tests/Feature/SuppressionEmailNormalizationMigrationTest.php
@@ -395,3 +395,18 @@ it('locks affected duplicate rows before deleting a loser', function () {
         ->toContain('->lockForUpdate()')
         ->and($migrationSource)->toMatch('/lockForUpdate\\(\\).*whereIn\\([^;]+delete\\(\\)/s');
 });
+
+it('uses binary indexed values and replaces the conflicting legacy unique index on supported drivers', function () {
+    $migrationSource = file_get_contents(suppressionEmailNormalizationMigrationFile());
+
+    expect($migrationSource)
+        ->toContain("private const ORIGINAL_UNIQUE_INDEX = 'suppressions_project_id_email_unique'")
+        ->toContain('VARBINARY(1020)')
+        ->toContain('CAST(')
+        ->toContain(' AS BINARY)')
+        ->toContain('Latin1_General_100_BIN2')
+        ->toMatch('/DROP INDEX.*ORIGINAL_UNIQUE_INDEX/s')
+        ->toMatch('/ADD UNIQUE INDEX.*ORIGINAL_UNIQUE_INDEX/s')
+        ->toContain('dropUnique(self::ORIGINAL_UNIQUE_INDEX)')
+        ->toContain("unique(['project_id', 'email'], self::ORIGINAL_UNIQUE_INDEX)");
+});

--- a/tests/Feature/SuppressionManagementTest.php
+++ b/tests/Feature/SuppressionManagementTest.php
@@ -1,0 +1,261 @@
+<?php
+
+use App\Models\ApiKey;
+use App\Models\Project;
+use App\Models\Source;
+use App\Models\Suppression;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * @return array{User, Workspace, Project, Source}
+ */
+function suppressionManagementFixture(string $slug, string $provider = 'ses'): array
+{
+    $owner = User::factory()->create();
+    $workspace = Workspace::create([
+        'owner_id' => $owner->id,
+        'name' => str($slug)->headline()->toString(),
+        'slug' => $slug,
+    ]);
+    $workspace->users()->attach($owner, ['role' => 'owner']);
+    $project = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => str($slug)->headline()->toString(),
+        'slug' => $slug,
+    ]);
+    $source = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Production',
+        'environment' => 'prod',
+        'provider' => $provider,
+        'ses_region' => 'us-east-1',
+        'aws_access_key_id' => 'test-access-key',
+        'aws_secret_access_key' => 'test-secret-key',
+        'cloudflare_api_token' => $provider === 'cloudflare' ? 'test-cloudflare-token' : null,
+        'cloudflare_account_id' => $provider === 'cloudflare' ? "account-{$slug}" : null,
+        'webhook_token' => 'token-'.str()->random(8),
+    ]);
+
+    return [$owner, $workspace, $project, $source];
+}
+
+function managedSuppression(Project $project, ?Source $source, string $email = 'blocked@example.com'): Suppression
+{
+    return Suppression::create([
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source?->id,
+        'email' => $email,
+        'reason' => 'hard_bounce',
+        'event_type' => 'bounce',
+    ]);
+}
+
+it('allows an owner to remove an SES suppression from the provider and project', function () {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://email.us-east-1.amazonaws.com/v2/email/suppression/addresses/*' => Http::response(status: 204),
+    ]);
+
+    [$owner, , $project, $source] = suppressionManagementFixture('owner-removal');
+    $suppression = managedSuppression($project, $source, 'Owner.Blocked@example.com');
+
+    $this->actingAs($owner)
+        ->get("/projects/{$project->slug}/suppressions")
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('workspace.can_manage_suppressions', true)
+        );
+
+    $this->actingAs($owner)
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}")
+        ->assertRedirect("/projects/{$project->slug}/suppressions");
+
+    $this->assertModelMissing($suppression);
+
+    Http::assertSent(fn (Request $request): bool => $request->method() === 'DELETE'
+        && str_ends_with($request->url(), '/v2/email/suppression/addresses/Owner.Blocked%40example.com')
+        && str_starts_with((string) $request->header('Authorization')[0], 'AWS4-HMAC-SHA256 '));
+});
+
+it('allows a member to remove an SES suppression when the provider already removed it', function () {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://email.us-east-1.amazonaws.com/v2/email/suppression/addresses/*' => Http::response([
+            'message' => 'Email address was not found.',
+        ], 404),
+    ]);
+
+    [, $workspace, $project, $source] = suppressionManagementFixture('member-removal');
+    $member = User::factory()->create();
+    $workspace->users()->attach($member, ['role' => 'member']);
+    $suppression = managedSuppression($project, $source);
+
+    $this->actingAs($member)
+        ->delete("/suppressions/{$suppression->id}")
+        ->assertRedirect('/suppressions');
+
+    $this->assertModelMissing($suppression);
+});
+
+it('forbids a sender from removing suppressions', function () {
+    [, $workspace, $project, $source] = suppressionManagementFixture('sender-forbidden');
+    $sender = User::factory()->create();
+    $workspace->users()->attach($sender, ['role' => 'sender']);
+    $suppression = managedSuppression($project, $source);
+
+    $this->actingAs($sender)
+        ->get("/projects/{$project->slug}/suppressions")
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('workspace.can_manage_suppressions', false)
+        );
+
+    $this->actingAs($sender)
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}")
+        ->assertForbidden();
+
+    $this->assertModelExists($suppression);
+});
+
+it('returns not found for a suppression outside the selected web project', function () {
+    [$owner, $workspace, $project] = suppressionManagementFixture('web-project-one');
+    $otherProject = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Project Two',
+        'slug' => 'web-project-two',
+    ]);
+    $suppression = managedSuppression($otherProject, null);
+
+    $this->actingAs($owner)
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}")
+        ->assertNotFound();
+
+    $this->assertModelExists($suppression);
+});
+
+it('preserves a suppression when SES refuses provider removal', function () {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://email.us-east-1.amazonaws.com/v2/email/suppression/addresses/*' => Http::response([
+            'message' => 'Access denied.',
+        ], 403),
+    ]);
+
+    [$owner, , $project, $source] = suppressionManagementFixture('ses-failure');
+    $suppression = managedSuppression($project, $source);
+
+    $response = $this->actingAs($owner)
+        ->from("/projects/{$project->slug}/suppressions")
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}");
+
+    $response
+        ->assertRedirect("/projects/{$project->slug}/suppressions")
+        ->assertSessionHasErrors('suppression');
+
+    expect(session('inertia.flash_data')['toast']['type'])->toBe('error');
+    $this->assertModelExists($suppression);
+});
+
+it('refuses local Cloudflare removal while the address remains upstream', function () {
+    Http::preventStrayRequests();
+    [$owner, , $project, $source] = suppressionManagementFixture('cloudflare-present', 'cloudflare');
+    $suppression = managedSuppression($project, $source);
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/account-cloudflare-present/email/sending/suppression*' => Http::sequence()
+            ->push([
+                'success' => true,
+                'result' => [
+                    [
+                        'id' => 'suppression-1',
+                        'email' => 'BLOCKED@example.com',
+                        'reason' => 'hard_bounce',
+                        'created_at' => now()->toIso8601String(),
+                        'expires_at' => null,
+                    ],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    $this->actingAs($owner)
+        ->from("/projects/{$project->slug}/suppressions")
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}")
+        ->assertRedirect("/projects/{$project->slug}/suppressions")
+        ->assertSessionHasErrors('suppression');
+
+    expect(session('errors')->get('suppression')[0])
+        ->toContain('Cloudflare')
+        ->toContain('upstream');
+    $this->assertModelExists($suppression);
+});
+
+it('removes the local Cloudflare blocker after a complete list confirms it is absent', function () {
+    Http::preventStrayRequests();
+    [$owner, , $project, $source] = suppressionManagementFixture('cloudflare-absent', 'cloudflare');
+    $suppression = managedSuppression($project, $source);
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/account-cloudflare-absent/email/sending/suppression*' => Http::sequence()
+            ->push([
+                'success' => true,
+                'result' => [
+                    [
+                        'id' => 'suppression-2',
+                        'email' => 'someone-else@example.com',
+                        'reason' => 'hard_bounce',
+                        'created_at' => now()->toIso8601String(),
+                        'expires_at' => null,
+                    ],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    $this->actingAs($owner)
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}")
+        ->assertRedirect("/projects/{$project->slug}/suppressions");
+
+    $this->assertModelMissing($suppression);
+});
+
+it('requires the manage suppressions scope for the API delete route', function () {
+    [, , $project, $source] = suppressionManagementFixture('api-scope');
+    $suppression = managedSuppression($project, null);
+    $readKey = ApiKey::issue($project, 'Read key', $source, ['read:activity']);
+    $manageKey = ApiKey::issue($project, 'Manage key', $source, ['manage:suppressions']);
+
+    $this->withToken($readKey['plain_text'])
+        ->deleteJson("/api/suppressions/{$suppression->id}")
+        ->assertForbidden()
+        ->assertJsonPath('message', 'This Larasend API key is missing the manage:suppressions scope.');
+
+    $this->assertModelExists($suppression);
+
+    $this->withToken($manageKey['plain_text'])
+        ->deleteJson("/api/suppressions/{$suppression->id}")
+        ->assertNoContent();
+
+    $this->assertModelMissing($suppression);
+});
+
+it('returns not found when an API key targets another project suppression', function () {
+    [, $workspace, $project, $source] = suppressionManagementFixture('api-project-one');
+    $otherProject = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => 'API Project Two',
+        'slug' => 'api-project-two',
+    ]);
+    $suppression = managedSuppression($otherProject, null);
+    $issued = ApiKey::issue($project, 'Manage key', $source, ['manage:suppressions']);
+
+    $this->withToken($issued['plain_text'])
+        ->deleteJson("/api/suppressions/{$suppression->id}")
+        ->assertNotFound();
+
+    $this->assertModelExists($suppression);
+});

--- a/tests/Feature/SuppressionManagementTest.php
+++ b/tests/Feature/SuppressionManagementTest.php
@@ -7,6 +7,9 @@ use App\Models\Suppression;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Http;
 
 /**
@@ -55,6 +58,8 @@ function managedSuppression(Project $project, ?Source $source, string $email = '
 }
 
 it('allows an owner to remove an SES suppression from the provider and project', function () {
+    $this->travelTo(Carbon::parse('2030-01-02 03:04:05 UTC'));
+
     Http::preventStrayRequests();
     Http::fake([
         'https://email.us-east-1.amazonaws.com/v2/email/suppression/addresses/*' => Http::response(status: 204),
@@ -76,9 +81,18 @@ it('allows an owner to remove an SES suppression from the provider and project',
 
     $this->assertModelMissing($suppression);
 
-    Http::assertSent(fn (Request $request): bool => $request->method() === 'DELETE'
-        && str_ends_with($request->url(), '/v2/email/suppression/addresses/Owner.Blocked%40example.com')
-        && str_starts_with((string) $request->header('Authorization')[0], 'AWS4-HMAC-SHA256 '));
+    Http::assertSent(function (Request $request): bool {
+        $expectedAuthorization = 'AWS4-HMAC-SHA256 Credential=test-access-key/20300102/us-east-1/ses/aws4_request, '
+            .'SignedHeaders=content-type;host;x-amz-date, '
+            .'Signature=0649cdec45840e86b0bc4dd45e22f29959c0c612c2480022955966414a0ea0d7';
+
+        return $request->method() === 'DELETE'
+            && str_ends_with($request->url(), '/v2/email/suppression/addresses/Owner.Blocked%40example.com')
+            && $request->header('X-Amz-Date')[0] === '20300102T030405Z'
+            && $request->header('Authorization')[0] === $expectedAuthorization;
+    });
+
+    $this->travelBack();
 });
 
 it('allows a member to remove an SES suppression when the provider already removed it', function () {
@@ -179,6 +193,19 @@ it('refuses local Cloudflare removal while the address remains upstream', functi
                     ],
                 ],
             ])
+            ->push(['success' => true, 'result' => []])
+            ->push([
+                'success' => true,
+                'result' => [
+                    [
+                        'id' => 'suppression-1',
+                        'email' => 'BLOCKED@example.com',
+                        'reason' => 'hard_bounce',
+                        'created_at' => now()->toIso8601String(),
+                        'expires_at' => null,
+                    ],
+                ],
+            ])
             ->push(['success' => true, 'result' => []]),
     ]);
 
@@ -201,6 +228,19 @@ it('removes the local Cloudflare blocker after a complete list confirms it is ab
 
     Http::fake([
         'https://api.cloudflare.com/client/v4/accounts/account-cloudflare-absent/email/sending/suppression*' => Http::sequence()
+            ->push([
+                'success' => true,
+                'result' => [
+                    [
+                        'id' => 'suppression-2',
+                        'email' => 'someone-else@example.com',
+                        'reason' => 'hard_bounce',
+                        'created_at' => now()->toIso8601String(),
+                        'expires_at' => null,
+                    ],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []])
             ->push([
                 'success' => true,
                 'result' => [
@@ -241,6 +281,100 @@ it('requires the manage suppressions scope for the API delete route', function (
         ->assertNoContent();
 
     $this->assertModelMissing($suppression);
+});
+
+it('returns conflict when Cloudflare still owns the suppression upstream', function () {
+    Http::preventStrayRequests();
+    [, , $project, $source] = suppressionManagementFixture('api-cloudflare-conflict', 'cloudflare');
+    $suppression = managedSuppression($project, $source);
+    $issued = ApiKey::issue($project, 'Manage key', $source, ['manage:suppressions']);
+    $upstream = [
+        'success' => true,
+        'result' => [[
+            'id' => 'suppression-conflict',
+            'email' => 'blocked@example.com',
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
+    ];
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/account-api-cloudflare-conflict/email/sending/suppression*' => Http::sequence()
+            ->push($upstream)
+            ->push(['success' => true, 'result' => []])
+            ->push($upstream)
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    $this->withToken($issued['plain_text'])
+        ->deleteJson("/api/suppressions/{$suppression->id}")
+        ->assertConflict()
+        ->assertJsonPath(
+            'message',
+            'Cloudflare still lists this address upstream and does not provide a suppression-removal API. Remove it in Cloudflare first, then retry.',
+        );
+
+    $this->assertModelExists($suppression);
+});
+
+it('returns service unavailable without exposing provider errors', function () {
+    Http::preventStrayRequests();
+    [, , $project, $source] = suppressionManagementFixture('api-provider-failure');
+    $suppression = managedSuppression($project, $source);
+    $issued = ApiKey::issue($project, 'Manage key', $source, ['manage:suppressions']);
+
+    Exceptions::fake();
+    Http::fake([
+        'https://email.us-east-1.amazonaws.com/v2/email/suppression/addresses/*' => Http::response([
+            'message' => 'super-secret-upstream-detail',
+        ], 403),
+    ]);
+
+    $this->withToken($issued['plain_text'])
+        ->deleteJson("/api/suppressions/{$suppression->id}")
+        ->assertServiceUnavailable()
+        ->assertJsonPath(
+            'message',
+            'Amazon SES could not remove this address right now. The local blocker was preserved. Try again later.',
+        )
+        ->assertJsonMissing(['message' => 'super-secret-upstream-detail']);
+
+    Exceptions::assertReported(RequestException::class);
+    $this->assertModelExists($suppression);
+});
+
+it('preserves a Cloudflare suppression when consecutive complete snapshots never stabilize', function () {
+    Http::preventStrayRequests();
+    [, , $project, $source] = suppressionManagementFixture('api-cloudflare-unstable', 'cloudflare');
+    $suppression = managedSuppression($project, $source);
+    $issued = ApiKey::issue($project, 'Manage key', $source, ['manage:suppressions']);
+    $snapshot = fn (string $id): array => [
+        'success' => true,
+        'result' => [[
+            'id' => $id,
+            'email' => "{$id}@example.com",
+            'reason' => 'hard_bounce',
+            'created_at' => now()->toIso8601String(),
+            'expires_at' => null,
+        ]],
+    ];
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/account-api-cloudflare-unstable/email/sending/suppression*' => Http::sequence()
+            ->push($snapshot('first'))
+            ->push(['success' => true, 'result' => []])
+            ->push($snapshot('second'))
+            ->push(['success' => true, 'result' => []])
+            ->push($snapshot('third'))
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    $this->withToken($issued['plain_text'])
+        ->deleteJson("/api/suppressions/{$suppression->id}")
+        ->assertServiceUnavailable();
+
+    $this->assertModelExists($suppression);
 });
 
 it('keeps legacy null-scoped API keys authorized while preserving project isolation', function () {

--- a/tests/Feature/SuppressionManagementTest.php
+++ b/tests/Feature/SuppressionManagementTest.php
@@ -84,10 +84,10 @@ it('allows an owner to remove an SES suppression from the provider and project',
     Http::assertSent(function (Request $request): bool {
         $expectedAuthorization = 'AWS4-HMAC-SHA256 Credential=test-access-key/20300102/us-east-1/ses/aws4_request, '
             .'SignedHeaders=content-type;host;x-amz-date, '
-            .'Signature=0649cdec45840e86b0bc4dd45e22f29959c0c612c2480022955966414a0ea0d7';
+            .'Signature=6c8e05635fbe79e963dc68d2bde55ac5c832128aad7af9afd6a1f8f2a1fbc188';
 
         return $request->method() === 'DELETE'
-            && str_ends_with($request->url(), '/v2/email/suppression/addresses/Owner.Blocked%40example.com')
+            && str_ends_with($request->url(), '/v2/email/suppression/addresses/owner.blocked%40example.com')
             && $request->header('X-Amz-Date')[0] === '20300102T030405Z'
             && $request->header('Authorization')[0] === $expectedAuthorization;
     });

--- a/tests/Feature/SuppressionManagementTest.php
+++ b/tests/Feature/SuppressionManagementTest.php
@@ -243,6 +243,32 @@ it('requires the manage suppressions scope for the API delete route', function (
     $this->assertModelMissing($suppression);
 });
 
+it('keeps legacy null-scoped API keys authorized while preserving project isolation', function () {
+    [, $workspace, $project, $source] = suppressionManagementFixture('api-legacy-scopes');
+    $ownedSuppression = managedSuppression($project, null, 'owned@example.com');
+    $otherProject = Project::create([
+        'workspace_id' => $workspace->id,
+        'name' => 'Legacy Other Project',
+        'slug' => 'api-legacy-other',
+    ]);
+    $otherSuppression = managedSuppression($otherProject, null, 'other@example.com');
+    $issued = ApiKey::issue($project, 'Legacy key', $source);
+
+    $issued['api_key']->forceFill(['scopes' => null])->save();
+
+    $this->withToken($issued['plain_text'])
+        ->deleteJson("/api/suppressions/{$otherSuppression->id}")
+        ->assertNotFound();
+
+    $this->assertModelExists($otherSuppression);
+
+    $this->withToken($issued['plain_text'])
+        ->deleteJson("/api/suppressions/{$ownedSuppression->id}")
+        ->assertNoContent();
+
+    $this->assertModelMissing($ownedSuppression);
+});
+
 it('returns not found when an API key targets another project suppression', function () {
     [, $workspace, $project, $source] = suppressionManagementFixture('api-project-one');
     $otherProject = Project::create([

--- a/tests/Feature/SuppressionManagementTest.php
+++ b/tests/Feature/SuppressionManagementTest.php
@@ -186,7 +186,7 @@ it('refuses local Cloudflare removal while the address remains upstream', functi
                 'result' => [
                     [
                         'id' => 'suppression-1',
-                        'email' => 'BLOCKED@example.com',
+                        'email' => ' BLOCKED@EXAMPLE.COM ',
                         'reason' => 'hard_bounce',
                         'created_at' => now()->toIso8601String(),
                         'expires_at' => null,
@@ -199,7 +199,7 @@ it('refuses local Cloudflare removal while the address remains upstream', functi
                 'result' => [
                     [
                         'id' => 'suppression-1',
-                        'email' => 'BLOCKED@example.com',
+                        'email' => ' BLOCKED@EXAMPLE.COM ',
                         'reason' => 'hard_bounce',
                         'created_at' => now()->toIso8601String(),
                         'expires_at' => null,
@@ -219,6 +219,48 @@ it('refuses local Cloudflare removal while the address remains upstream', functi
         ->toContain('Cloudflare')
         ->toContain('upstream');
     $this->assertModelExists($suppression);
+});
+
+it('removes a local Cloudflare blocker when upstream contains only a distinct non-ASCII variant', function () {
+    Http::preventStrayRequests();
+    [$owner, , $project, $source] = suppressionManagementFixture('cloudflare-non-ascii-distinct', 'cloudflare');
+    $suppression = managedSuppression($project, $source, ' ÄBC@example.com ');
+
+    Http::fake([
+        'https://api.cloudflare.com/client/v4/accounts/account-cloudflare-non-ascii-distinct/email/sending/suppression*' => Http::sequence()
+            ->push([
+                'success' => true,
+                'result' => [
+                    [
+                        'id' => 'suppression-non-ascii',
+                        'email' => 'äBC@example.com',
+                        'reason' => 'hard_bounce',
+                        'created_at' => now()->toIso8601String(),
+                        'expires_at' => null,
+                    ],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []])
+            ->push([
+                'success' => true,
+                'result' => [
+                    [
+                        'id' => 'suppression-non-ascii',
+                        'email' => 'äBC@example.com',
+                        'reason' => 'hard_bounce',
+                        'created_at' => now()->toIso8601String(),
+                        'expires_at' => null,
+                    ],
+                ],
+            ])
+            ->push(['success' => true, 'result' => []]),
+    ]);
+
+    $this->actingAs($owner)
+        ->delete("/projects/{$project->slug}/suppressions/{$suppression->id}")
+        ->assertRedirect("/projects/{$project->slug}/suppressions");
+
+    $this->assertModelMissing($suppression);
 });
 
 it('removes the local Cloudflare blocker after a complete list confirms it is absent', function () {


### PR DESCRIPTION
## Summary

Fixes the suppression lifecycle and management gaps described in #10.

- Treats expired suppressions as history instead of active send blockers.
- Adds database-backed active, bounce, complaint, and expired statistics to the Suppressions dashboard.
- Adds capability-gated suppression removal for the dashboard and API through the new `manage_suppressions` workspace capability and `manage:suppressions` API-key scope.
- Removes Amazon SES suppressions provider-first using a correctly signed SES v2 request; provider failures preserve the local blocker.
- Reconciles Cloudflare suppressions only from bounded, stable snapshots and never prunes after pagination drift, timeout, page-limit, or provider failure.
- Adds source ownership, concurrency, uniqueness, pagination, and job-overlap safeguards.
- Normalizes historical suppression addresses and enforces normalized uniqueness through a new migration.
- Improves the suppression CSV export and protects spreadsheet consumers from formula injection.
- Updates the dashboard with active/expired state, provider-aware confirmation messaging, pending/error behavior, and light/dark styling.
- Documents the additional `ses:DeleteSuppressedDestination` IAM permission.

## Root cause

Suppression state was treated as an append-only local record. Expiration was not included in the send guard, Cloudflare sync did not safely reconcile deletions, SES removal was not implemented upstream, and there was no authorized removal path in the dashboard or API. Provider pagination, source collisions, case normalization, and queue overlap also made naive deletion unsafe.

## User impact

Workspace owners and members can now understand why an address is blocked and safely remove eligible suppressions. Expired records remain visible without blocking delivery. Sender-only users and API keys without the destructive scope cannot remove suppressions, and cross-project record IDs return 404.

## Validation

- Full PHP suite: 261 tests, 1,732 assertions.
- Focused suppression suite: 85 tests, 639 assertions.
- Laravel Pint passed.
- Vue TypeScript check passed.
- Production Vite build passed.
- Changed `Activity.vue` passes targeted Prettier and ESLint checks.
- Suppression route registration and `git diff --check` passed.
- Repeated independent whole-branch review approved with no actionable findings.

Repository-wide Prettier/ESLint still report existing issues in four untouched baseline files; none are part of this PR.

## Database note

SQLite migration and rollback paths were executed locally. PostgreSQL, MySQL/MariaDB, and SQL Server branches include driver-specific normalized-index and atomic-write contracts with regression coverage, but those DDL/MERGE paths were source-reviewed rather than executed against live instances.

Closes #10.