### PR TITLE
Refresh homepage, dashboard, and account navigation

### DIFF
--- a/app/Actions/BuildProjectDashboard.php
+++ b/app/Actions/BuildProjectDashboard.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Project;
+use App\Models\Source;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Carbon\CarbonInterface;
+
+class BuildProjectDashboard
+{
+    /**
+     * @param  array{worker_alive: bool, worker_last_seen: ?string, scheduler_alive: bool, scheduler_last_seen: ?string, stuck_queued: int}  $system
+     * @param  array{sent: int, limit: ?int, rate: ?int, sentLast24Hours: ?int, checkedAt: ?string}  $quota
+     * @return array<string, mixed>
+     */
+    public function execute(
+        Project $project,
+        ?Source $source,
+        User $user,
+        string $range,
+        CarbonInterface $currentStart,
+        CarbonInterface $currentEnd,
+        array $system,
+        array $quota,
+        int $inboxUnread,
+        bool $sourceReady,
+    ): array {
+        $outbound = $project->emails()
+            ->whereBetween('created_at', [$currentStart, $currentEnd])
+            ->toBase()
+            ->selectRaw('count(*) as total')
+            ->selectRaw("count(case when status = 'failed' then 1 end) as failed")
+            ->selectRaw("count(case when status = 'queued' then 1 end) as queued")
+            ->selectRaw("count(case when status = 'bounced' then 1 end) as bounced")
+            ->selectRaw("count(case when status = 'complained' then 1 end) as complained")
+            ->first();
+
+        $activeThreads = $project->threads()
+            ->whereNull('archived_at')
+            ->where('status', '!=', 'closed')
+            ->where(fn ($query) => $query
+                ->whereNull('snoozed_until')
+                ->orWhere('snoozed_until', '<=', now()))
+            ->toBase()
+            ->selectRaw('count(*) as open')
+            ->selectRaw("count(case when status = 'pending' then 1 end) as pending")
+            ->selectRaw("count(case when priority = 'urgent' then 1 end) as urgent")
+            ->selectRaw('count(case when assigned_to_user_id is null then 1 end) as unassigned')
+            ->selectRaw('count(case when assigned_to_user_id = ? then 1 end) as mine', [$user->id])
+            ->first();
+
+        $domains = $project->domains()
+            ->toBase()
+            ->selectRaw('count(*) as total')
+            ->selectRaw("count(case when status in ('verified', 'local') then 1 end) as verified")
+            ->selectRaw('count(case when inbound_enabled_at is not null then 1 end) as inbound')
+            ->first();
+
+        $now = now();
+        $apiKeys = $project->apiKeys()
+            ->toBase()
+            ->selectRaw('count(*) as total')
+            ->selectRaw('count(case when expires_at > ? and expires_at <= ? then 1 end) as expiring', [$now, $now->copy()->addDays(7)])
+            ->first();
+
+        $failingWebhooks = WebhookDelivery::query()
+            ->whereIn('webhook_endpoint_id', $project->webhookEndpoints()->select('id'))
+            ->where('status', 'fail')
+            ->whereBetween('delivered_at', [$currentStart, $currentEnd])
+            ->count();
+
+        $summary = [
+            'outbound' => [
+                'total' => (int) ($outbound->total ?? 0),
+                'failed' => (int) ($outbound->failed ?? 0),
+                'queued' => (int) ($outbound->queued ?? 0),
+                'bounced' => (int) ($outbound->bounced ?? 0),
+                'complained' => (int) ($outbound->complained ?? 0),
+            ],
+            'inbox' => [
+                'open' => (int) ($activeThreads->open ?? 0),
+                'unread' => $inboxUnread,
+                'mine' => (int) ($activeThreads->mine ?? 0),
+                'unassigned' => (int) ($activeThreads->unassigned ?? 0),
+                'urgent' => (int) ($activeThreads->urgent ?? 0),
+                'pending' => (int) ($activeThreads->pending ?? 0),
+                'snoozed' => $project->threads()->where('snoozed_until', '>', now())->count(),
+            ],
+            'configuration' => [
+                'provider' => $source?->provider->label() ?? 'Not connected',
+                'source_ready' => $sourceReady,
+                'domains' => (int) ($domains->total ?? 0),
+                'verified_domains' => (int) ($domains->verified ?? 0),
+                'inbound_domains' => (int) ($domains->inbound ?? 0),
+                'quota' => $quota,
+            ],
+            'developer' => [
+                'active_webhooks' => $project->webhookEndpoints()->where('status', 'active')->count(),
+                'failing_webhooks' => $failingWebhooks,
+                'api_keys' => (int) ($apiKeys->total ?? 0),
+                'expiring_api_keys' => (int) ($apiKeys->expiring ?? 0),
+            ],
+            'trend' => $this->trend($project, $range, $currentStart, $currentEnd),
+        ];
+
+        return [
+            ...$summary,
+            'attention' => $this->attention($summary, $system),
+        ];
+    }
+
+    /**
+     * @return array<int, array{label: string, sent: int, delivered: int, failed: int}>
+     */
+    private function trend(Project $project, string $range, CarbonInterface $start, CarbonInterface $end): array
+    {
+        $bucketCount = $range === '1h' ? 6 : 8;
+        $bucketSeconds = max(1, (int) ceil($start->diffInSeconds($end) / $bucketCount));
+        $query = $project->emails()
+            ->where('created_at', '>=', $start)
+            ->where('created_at', '<', $end->copy()->addSecond())
+            ->toBase()
+            ->selectRaw('count(*) as aggregate_guard');
+        $buckets = [];
+
+        foreach (range(0, $bucketCount - 1) as $index) {
+            $bucketStart = $start->copy()->addSeconds($bucketSeconds * $index);
+            $bucketEnd = $index === $bucketCount - 1
+                ? $end->copy()->addSecond()
+                : $start->copy()->addSeconds($bucketSeconds * ($index + 1));
+
+            $query
+                ->selectRaw("count(case when created_at >= ? and created_at < ? then 1 end) as sent_{$index}", [$bucketStart, $bucketEnd])
+                ->selectRaw("count(case when created_at >= ? and created_at < ? and status in ('delivered', 'opened', 'clicked') then 1 end) as delivered_{$index}", [$bucketStart, $bucketEnd])
+                ->selectRaw("count(case when created_at >= ? and created_at < ? and status in ('failed', 'bounced', 'complained') then 1 end) as failed_{$index}", [$bucketStart, $bucketEnd]);
+
+            $buckets[] = [
+                'label' => $this->bucketLabel($range, $bucketStart),
+                'sent_key' => "sent_{$index}",
+                'delivered_key' => "delivered_{$index}",
+                'failed_key' => "failed_{$index}",
+            ];
+        }
+
+        $counts = $query->first();
+
+        return collect($buckets)->map(fn (array $bucket): array => [
+            'label' => $bucket['label'],
+            'sent' => (int) ($counts->{$bucket['sent_key']} ?? 0),
+            'delivered' => (int) ($counts->{$bucket['delivered_key']} ?? 0),
+            'failed' => (int) ($counts->{$bucket['failed_key']} ?? 0),
+        ])->all();
+    }
+
+    private function bucketLabel(string $range, CarbonInterface $start): string
+    {
+        return match ($range) {
+            '1h', '24h' => $start->format('g a'),
+            '7d' => $start->format('D'),
+            default => $start->format('M j'),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @param  array<string, mixed>  $system
+     * @return array<int, array{key: string, label: string, description: string, count: int, section: string, tone: string}>
+     */
+    private function attention(array $summary, array $system): array
+    {
+        $items = [
+            ['key' => 'failed', 'label' => 'Failed sends', 'description' => 'Messages that need investigation or a retry.', 'count' => $summary['outbound']['failed'], 'section' => 'outbound', 'tone' => 'danger'],
+            ['key' => 'urgent', 'label' => 'Urgent conversations', 'description' => 'High-priority inbox work awaiting the team.', 'count' => $summary['inbox']['urgent'], 'section' => 'inbox', 'tone' => 'danger'],
+            ['key' => 'unassigned', 'label' => 'Unassigned conversations', 'description' => 'Open conversations without an owner.', 'count' => $summary['inbox']['unassigned'], 'section' => 'inbox', 'tone' => 'warning'],
+            ['key' => 'webhooks', 'label' => 'Webhook failures', 'description' => 'Failed webhook deliveries in this period.', 'count' => $summary['developer']['failing_webhooks'], 'section' => 'webhooks', 'tone' => 'warning'],
+            ['key' => 'api-keys', 'label' => 'API keys expiring soon', 'description' => 'Keys expiring within the next seven days.', 'count' => $summary['developer']['expiring_api_keys'], 'section' => 'api-keys', 'tone' => 'warning'],
+            ['key' => 'queue', 'label' => 'Queued messages are stuck', 'description' => 'The queue worker may need attention.', 'count' => $system['stuck_queued'], 'section' => 'outbound', 'tone' => 'danger'],
+        ];
+
+        if (! $system['worker_alive']) {
+            $items[] = ['key' => 'worker', 'label' => 'Queue worker not detected', 'description' => 'Outbound delivery can pause until the worker returns.', 'count' => 1, 'section' => 'source', 'tone' => 'danger'];
+        }
+
+        if (! $system['scheduler_alive']) {
+            $items[] = ['key' => 'scheduler', 'label' => 'Scheduler not detected', 'description' => 'Quota and suppression syncs may be delayed.', 'count' => 1, 'section' => 'source', 'tone' => 'warning'];
+        }
+
+        return collect($items)->filter(fn (array $item): bool => $item['count'] > 0)->values()->all();
+    }
+}

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\BuildProjectDashboard;
 use App\Enums\SourceProvider;
 use App\Models\Email;
 use App\Models\Project;
@@ -28,6 +29,7 @@ class ActivityController extends Controller
     public function __construct(
         private EmailProviderFactory $providers,
         private SystemHealth $systemHealth,
+        private BuildProjectDashboard $buildProjectDashboard,
     ) {}
 
     public function __invoke(Request $request, ProjectContext $context): Response|RedirectResponse
@@ -66,6 +68,33 @@ class ActivityController extends Controller
 
         $selected = $emails->first();
         $canSend = $source ? $this->canSend($project, $source) : false;
+        $range = $request->string('range', '14d')->toString();
+        $system = [
+            'worker_alive' => $this->systemHealth->workerIsAlive(),
+            'worker_last_seen' => $this->systemHealth->workerHeartbeatAt()?->diffForHumans(),
+            'scheduler_alive' => $this->systemHealth->schedulerIsAlive(),
+            'scheduler_last_seen' => $this->systemHealth->schedulerHeartbeatAt()?->diffForHumans(),
+            'stuck_queued' => $this->systemHealth->stuckQueuedEmailCount($project),
+        ];
+        $inboxUnread = $this->unreadInboxThreads($project, $user)->count();
+        $quota = $this->quota($project, $source);
+        $dashboard = null;
+
+        if ($section === 'activity') {
+            [$currentStart, $currentEnd] = $this->metricPeriods($range);
+            $dashboard = $this->buildProjectDashboard->execute(
+                project: $project,
+                source: $source,
+                user: $user,
+                range: $range,
+                currentStart: $currentStart,
+                currentEnd: $currentEnd,
+                system: $system,
+                quota: $quota,
+                inboxUnread: $inboxUnread,
+                sourceReady: $canSend,
+            );
+        }
 
         return Inertia::render('Activity', [
             'project' => [
@@ -115,9 +144,10 @@ class ActivityController extends Controller
             'section' => $section,
             'filters' => [
                 'q' => $request->string('q')->toString(),
-                'range' => $request->string('range', '14d')->toString(),
+                'range' => $range,
             ],
-            'metrics' => $this->metrics($project, $request->string('range', '14d')->toString()),
+            'metrics' => $this->metrics($project, $range),
+            'dashboard' => $dashboard,
             'bounceMetrics' => $this->bounceMetrics($project),
             'bounceQueue' => $this->bounceQueue($project, $request),
             'emails' => $emails->map(fn (Email $email) => $this->serializeEmail($email, detailed: true)),
@@ -172,9 +202,13 @@ class ActivityController extends Controller
                 'complaints' => $project->emails()->where('status', 'complained')->count(),
                 'suppressions' => $project->suppressions()->active()->count(),
             ],
-            'inboxUnread' => $this->activeInboxThreads($project)->whereNull('read_at')->count(),
+            'inboxUnread' => $inboxUnread,
             'recentThreads' => $section === 'activity'
                 ? $this->activeInboxThreads($project)
+                    ->with([
+                        'assignedTo:id,name',
+                        'userStates' => fn ($query) => $query->where('user_id', $user->id),
+                    ])
                     ->orderByDesc('last_activity_at')
                     ->limit(5)
                     ->get([
@@ -185,19 +219,16 @@ class ActivityController extends Controller
                         'last_direction',
                         'message_count',
                         'read_at',
+                        'status',
+                        'priority',
+                        'assigned_to_user_id',
                         'last_activity_at',
                     ])
-                    ->map(fn (Thread $thread): array => $this->serializeThreadSummary($thread))
+                    ->map(fn (Thread $thread): array => $this->serializeThreadSummary($thread, $user->id))
                     ->values()
                 : [],
-            'quota' => $this->quota($project, $source),
-            'system' => [
-                'worker_alive' => $this->systemHealth->workerIsAlive(),
-                'worker_last_seen' => $this->systemHealth->workerHeartbeatAt()?->diffForHumans(),
-                'scheduler_alive' => $this->systemHealth->schedulerIsAlive(),
-                'scheduler_last_seen' => $this->systemHealth->schedulerHeartbeatAt()?->diffForHumans(),
-                'stuck_queued' => $this->systemHealth->stuckQueuedEmailCount($project),
-            ],
+            'quota' => $quota,
+            'system' => $system,
         ]);
     }
 
@@ -411,17 +442,28 @@ class ActivityController extends Controller
     {
         return $project->threads()
             ->whereNull('archived_at')
+            ->where('status', '!=', 'closed')
             ->where(function ($query): void {
                 $query->whereNull('snoozed_until')
                     ->orWhere('snoozed_until', '<=', now());
             });
     }
 
+    private function unreadInboxThreads(Project $project, User $user): HasMany
+    {
+        return $this->activeInboxThreads($project)
+            ->whereDoesntHave('userStates', fn ($query) => $query
+                ->where('user_id', $user->id)
+                ->whereNotNull('read_at'));
+    }
+
     /**
      * @return array<string, mixed>
      */
-    private function serializeThreadSummary(Thread $thread): array
+    private function serializeThreadSummary(Thread $thread, int $userId): array
     {
+        $userState = $thread->userStates->firstWhere('user_id', $userId);
+
         return [
             'public_id' => $thread->public_id,
             'subject' => $thread->subject,
@@ -429,7 +471,10 @@ class ActivityController extends Controller
             'snippet' => $thread->last_snippet,
             'direction' => $thread->last_direction,
             'message_count' => $thread->message_count,
-            'unread' => $thread->read_at === null,
+            'unread' => $userState?->read_at === null,
+            'status' => $thread->status,
+            'priority' => $thread->priority,
+            'assigned_to' => $thread->assignedTo?->name,
             'last_activity_at' => $thread->last_activity_at?->toIso8601String(),
             'last_activity_human' => $thread->last_activity_at?->diffForHumans(short: true),
         ];
@@ -517,7 +562,9 @@ class ActivityController extends Controller
     {
         $endpointIds = $project->webhookEndpoints()->pluck('id');
         $endpoints = $project->webhookEndpoints()->with('latestDelivery')->get();
-        $deliveries = WebhookDelivery::query()->whereIn('webhook_endpoint_id', $endpointIds);
+        $deliveries = WebhookDelivery::query()
+            ->whereIn('webhook_endpoint_id', $endpointIds)
+            ->where('delivered_at', '>=', now()->subDays(30));
         $total = (clone $deliveries)->count();
         $success = (clone $deliveries)->where('status', 'ok')->count();
         $failing = $endpoints->filter(fn (WebhookEndpoint $endpoint) => $this->webhookStatusFor($endpoint) === 'failing')->count();
@@ -570,14 +617,17 @@ class ActivityController extends Controller
     }
 
     /**
-     * @return array{sent: int, limit: int|null, rate: float|null, checkedAt: string|null}
+     * @return array{sent: int, limit: int|null, rate: float|null, sentLast24Hours: float|null, checkedAt: string|null}
      */
     private function quota(Project $project, ?Source $source): array
     {
         $lastQuota = $source?->last_quota ?? [];
 
         return [
-            'sent' => $project->emails()->where('created_at', '>=', now()->subDays(30))->count(),
+            'sent' => $project->emails()
+                ->where('created_at', '>=', now()->subDays(30))
+                ->whereNotIn('status', ['queued', 'failed'])
+                ->count(),
             'limit' => $this->quotaValue($lastQuota, ['Max24HourSend', 'max24HourSend', 'max_24_hour_send']),
             'rate' => $this->quotaValue($lastQuota, ['MaxSendRate', 'maxSendRate', 'max_send_rate']),
             'sentLast24Hours' => $this->quotaValue($lastQuota, ['SentLast24Hours', 'sentLast24Hours', 'sent_last_24_hours']),
@@ -722,17 +772,25 @@ class ActivityController extends Controller
      */
     private function metricCounts(Project $project, CarbonInterface $start, CarbonInterface $end): array
     {
-        $baseQuery = $project->emails()
+        $counts = $project->emails()
             ->where('created_at', '>=', $start)
-            ->where('created_at', '<=', $end);
+            ->where('created_at', '<=', $end)
+            ->toBase()
+            ->selectRaw("count(case when status not in ('queued', 'failed') then 1 end) as sent")
+            ->selectRaw("count(case when status in ('delivered', 'opened', 'clicked') then 1 end) as delivered")
+            ->selectRaw("count(case when status in ('opened', 'clicked') then 1 end) as opened")
+            ->selectRaw("count(case when status = 'clicked' then 1 end) as clicked")
+            ->selectRaw("count(case when status = 'bounced' then 1 end) as bounced")
+            ->selectRaw("count(case when status = 'complained' then 1 end) as complained")
+            ->first();
 
         return [
-            'sent' => (clone $baseQuery)->count(),
-            'delivered' => (clone $baseQuery)->whereIn('status', ['delivered', 'opened', 'clicked'])->count(),
-            'opened' => (clone $baseQuery)->whereIn('status', ['opened', 'clicked'])->count(),
-            'clicked' => (clone $baseQuery)->where('status', 'clicked')->count(),
-            'bounced' => (clone $baseQuery)->where('status', 'bounced')->count(),
-            'complained' => (clone $baseQuery)->where('status', 'complained')->count(),
+            'sent' => (int) ($counts->sent ?? 0),
+            'delivered' => (int) ($counts->delivered ?? 0),
+            'opened' => (int) ($counts->opened ?? 0),
+            'clicked' => (int) ($counts->clicked ?? 0),
+            'bounced' => (int) ($counts->bounced ?? 0),
+            'complained' => (int) ($counts->complained ?? 0),
         ];
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,11 +2,16 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Project;
+use App\Models\User;
+use App\Support\ProjectContext;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
 {
+    public function __construct(private ProjectContext $projects) {}
+
     /**
      * The root template that's loaded on the first page visit.
      *
@@ -45,7 +50,85 @@ class HandleInertiaRequests extends Middleware
                 'version' => config('app.version'),
                 'sha' => config('app.git_sha'),
             ],
+            'settingsNavigation' => fn (): ?array => $this->settingsNavigation($request),
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function settingsNavigation(Request $request): ?array
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User || ! $request->routeIs('profile.*', 'security.*', 'appearance.*')) {
+            return null;
+        }
+
+        $workspace = $user->workspaces()->orderBy('workspaces.id')->first();
+
+        if (! $workspace) {
+            return null;
+        }
+
+        $projects = $workspace->projects()
+            ->with('sources')
+            ->whereNull('archived_at')
+            ->orderBy('name')
+            ->get();
+        $currentProjectSlug = session('current_project_slug');
+        $project = is_string($currentProjectSlug)
+            ? $projects->firstWhere('slug', $currentProjectSlug)
+            : null;
+        $project ??= $projects->first();
+
+        if (! $project) {
+            return null;
+        }
+
+        $projectCounts = Project::query()
+            ->whereKey($project->id)
+            ->withCount([
+                'emails as activity_count',
+                'inboundEmails as inbound_count',
+                'emails as bounces_count' => fn ($query) => $query->where('status', 'bounced'),
+                'emails as complaints_count' => fn ($query) => $query->where('status', 'complained'),
+                'suppressions as suppressions_count' => fn ($query) => $query->active(),
+            ])
+            ->firstOrFail();
+
+        return [
+            'project' => [
+                'name' => $project->name,
+                'slug' => $project->slug,
+                'path' => '/projects/'.$project->slug,
+            ],
+            'projects' => $projects->map(fn (Project $workspaceProject): array => [
+                'name' => $workspaceProject->name,
+                'slug' => $workspaceProject->slug,
+                'environment' => $workspaceProject->sources->first()?->environment ?? $workspaceProject->default_environment,
+                'provider_label' => $workspaceProject->sources->first()?->provider->label() ?? 'Not connected',
+                'is_current' => $workspaceProject->is($project),
+                'href' => $this->projects->sectionPath($workspaceProject, 'activity'),
+            ])->values(),
+            'counts' => [
+                'activity' => $projectCounts->activity_count,
+                'inbound' => $projectCounts->inbound_count,
+                'bounces' => $projectCounts->bounces_count,
+                'complaints' => $projectCounts->complaints_count,
+                'suppressions' => $projectCounts->suppressions_count,
+            ],
+            'inbox_unread' => $project->threads()
+                ->whereNull('archived_at')
+                ->where('status', '!=', 'closed')
+                ->where(fn ($query) => $query
+                    ->whereNull('snoozed_until')
+                    ->orWhere('snoozed_until', '<=', now()))
+                ->whereDoesntHave('userStates', fn ($query) => $query
+                    ->where('user_id', $user->id)
+                    ->whereNotNull('read_at'))
+                ->count(),
         ];
     }
 }

--- a/resources/js/components/DashboardPanel.vue
+++ b/resources/js/components/DashboardPanel.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
 import {
+    Activity,
     AlertTriangle,
     ArrowUpRight,
     CheckCircle2,
+    CircleDot,
+    Clock3,
+    Globe2,
     Inbox,
-    Send,
+    KeyRound,
+    Server,
+    UserRoundCheck,
+    Webhook,
 } from 'lucide-vue-next';
 import { computed } from 'vue';
 import { section as projectSection } from '@/routes/projects';
@@ -31,10 +38,64 @@ type ThreadSummary = {
     subject: string | null;
     participants: string[];
     snippet: string | null;
-    direction: string | null;
     message_count: number;
     unread: boolean;
+    status: string;
+    priority: string;
+    assigned_to: string | null;
     last_activity_human: string | null;
+};
+
+type Dashboard = {
+    outbound: {
+        total: number;
+        failed: number;
+        queued: number;
+        bounced: number;
+        complained: number;
+    };
+    inbox: {
+        open: number;
+        unread: number;
+        mine: number;
+        unassigned: number;
+        urgent: number;
+        pending: number;
+        snoozed: number;
+    };
+    configuration: {
+        provider: string;
+        source_ready: boolean;
+        domains: number;
+        verified_domains: number;
+        inbound_domains: number;
+        quota: {
+            sent: number;
+            limit: number | null;
+            sentLast24Hours: number | null;
+            checkedAt: string | null;
+        };
+    };
+    developer: {
+        active_webhooks: number;
+        failing_webhooks: number;
+        api_keys: number;
+        expiring_api_keys: number;
+    };
+    trend: {
+        label: string;
+        sent: number;
+        delivered: number;
+        failed: number;
+    }[];
+    attention: {
+        key: string;
+        label: string;
+        description: string;
+        count: number;
+        section: string;
+        tone: string;
+    }[];
 };
 
 const props = defineProps<{
@@ -42,8 +103,7 @@ const props = defineProps<{
     metrics: Metric[];
     emails: EmailRow[];
     recentThreads: ThreadSummary[];
-    inboxUnread: number;
-    sourceReady: boolean;
+    dashboard: Dashboard;
     system: {
         worker_alive: boolean;
         worker_last_seen: string | null;
@@ -54,9 +114,36 @@ const props = defineProps<{
 }>();
 
 const recentOutbound = computed(() => props.emails.slice(0, 5));
-const systemReady = computed(
-    () => props.system.worker_alive && props.system.scheduler_alive,
+const maxTrendValue = computed(() =>
+    Math.max(...props.dashboard.trend.map((point) => point.sent), 1),
 );
+const quotaPercent = computed(() => {
+    const quota = props.dashboard.configuration.quota;
+    const sent = quota.sentLast24Hours ?? quota.sent;
+
+    return quota.limit
+        ? Math.min(100, Math.round((sent / quota.limit) * 100))
+        : null;
+});
+
+function sectionUrl(section: string, query?: Record<string, string>): string {
+    return projectSection.url(
+        { project: props.projectSlug, section },
+        query ? { query } : undefined,
+    );
+}
+
+function metricUrl(metric: Metric): string {
+    if (metric.label === 'Bounce rate') {
+        return sectionUrl('bounces');
+    }
+
+    if (metric.label === 'Complaints') {
+        return sectionUrl('complaints');
+    }
+
+    return sectionUrl('outbound');
+}
 
 function metricTone(metric: Metric): string {
     if (metric.tone === 'good') {
@@ -82,25 +169,122 @@ function statusTone(status: string): string {
     return 'bg-amber-500/10 text-amber-700 dark:text-amber-300';
 }
 
-function sectionUrl(section: string): string {
-    return projectSection.url({ project: props.projectSlug, section });
+function attentionTone(tone: string): string {
+    return tone === 'danger'
+        ? 'border-red-200 bg-red-50/80 text-red-700 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-200'
+        : 'border-amber-200 bg-amber-50/80 text-amber-700 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-200';
 }
 </script>
 
 <template>
-    <div class="grid max-w-7xl gap-5">
+    <div class="grid max-w-7xl gap-5 pb-2">
+        <section
+            v-if="dashboard.attention.length"
+            class="rounded-xl border border-amber-200 bg-amber-50/60 p-4 dark:border-amber-500/20 dark:bg-amber-500/5"
+        >
+            <div class="flex items-start gap-3">
+                <span
+                    class="grid size-9 shrink-0 place-items-center rounded-lg bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                >
+                    <AlertTriangle class="size-4" />
+                </span>
+                <div class="min-w-0 flex-1">
+                    <div
+                        class="flex flex-wrap items-center justify-between gap-2"
+                    >
+                        <div>
+                            <h2 class="text-sm font-semibold">
+                                Needs attention
+                            </h2>
+                            <p class="mt-0.5 text-xs text-zinc-500">
+                                Operational issues and team work that should be
+                                handled next.
+                            </p>
+                        </div>
+                        <span
+                            class="rounded-full bg-amber-500/10 px-2.5 py-1 font-mono text-[10px] font-semibold text-amber-700 dark:text-amber-300"
+                        >
+                            {{ dashboard.attention.length }}
+                            {{
+                                dashboard.attention.length === 1
+                                    ? 'item'
+                                    : 'items'
+                            }}
+                        </span>
+                    </div>
+                    <div class="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                        <Link
+                            v-for="item in dashboard.attention"
+                            :key="item.key"
+                            :href="
+                                sectionUrl(
+                                    item.section,
+                                    item.key === 'unassigned'
+                                        ? { assigned: 'unassigned' }
+                                        : undefined,
+                                )
+                            "
+                            class="group flex items-center gap-3 rounded-lg border px-3 py-2.5 transition hover:-translate-y-0.5 hover:shadow-sm"
+                            :class="attentionTone(item.tone)"
+                        >
+                            <strong class="font-mono text-lg">{{
+                                item.count
+                            }}</strong>
+                            <span class="min-w-0 flex-1">
+                                <span
+                                    class="block truncate text-xs font-semibold"
+                                    >{{ item.label }}</span
+                                >
+                                <span
+                                    class="mt-0.5 block truncate text-[11px] opacity-70"
+                                    >{{ item.description }}</span
+                                >
+                            </span>
+                            <ArrowUpRight
+                                class="size-3.5 shrink-0 opacity-60 transition group-hover:opacity-100"
+                            />
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section
+            v-else
+            class="flex items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-500/20 dark:bg-emerald-500/5"
+        >
+            <span
+                class="grid size-9 place-items-center rounded-lg bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+            >
+                <CheckCircle2 class="size-4" />
+            </span>
+            <div>
+                <h2 class="text-sm font-semibold">Everything looks healthy</h2>
+                <p class="mt-0.5 text-xs text-zinc-500">
+                    No delivery, inbox, webhook, or infrastructure issues need
+                    attention.
+                </p>
+            </div>
+        </section>
+
         <section
             class="grid grid-cols-2 overflow-hidden rounded-xl border border-zinc-200 bg-white sm:grid-cols-3 xl:grid-cols-6 dark:border-[#25292d] dark:bg-[#111315]"
         >
-            <div
+            <Link
                 v-for="metric in metrics"
                 :key="metric.label"
-                class="min-w-0 border-r border-b border-zinc-200 p-4 last:border-r-0 sm:nth-[3n]:border-r-0 xl:border-b-0 xl:nth-[3n]:border-r xl:nth-[6n]:border-r-0 dark:border-[#25292d]"
+                :href="metricUrl(metric)"
+                class="group min-w-0 border-r border-b border-zinc-200 p-4 transition hover:bg-zinc-50 sm:nth-[3n]:border-r-0 xl:border-b-0 xl:nth-[3n]:border-r xl:nth-[6n]:border-r-0 dark:border-[#25292d] dark:hover:bg-[#16191c]"
             >
-                <div
-                    class="truncate font-mono text-[10px] font-semibold tracking-widest text-zinc-500 uppercase"
-                >
-                    {{ metric.label }}
+                <div class="flex items-center justify-between gap-2">
+                    <div
+                        class="truncate font-mono text-[10px] font-semibold tracking-widest text-zinc-500 uppercase"
+                    >
+                        {{ metric.label }}
+                    </div>
+                    <ArrowUpRight
+                        class="size-3 text-zinc-300 transition group-hover:text-zinc-600 dark:group-hover:text-zinc-300"
+                    />
                 </div>
                 <div class="mt-2 text-2xl font-semibold tracking-tight">
                     {{ metric.value }}
@@ -122,86 +306,248 @@ function sectionUrl(section: string): string {
                 <div v-else class="mt-1.5 font-mono text-[10px] text-zinc-400">
                     selected period
                 </div>
-            </div>
+            </Link>
         </section>
 
-        <section class="grid gap-4 sm:grid-cols-3">
-            <Link
-                :href="sectionUrl('inbox')"
-                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315] dark:hover:border-zinc-600"
+        <section
+            class="grid gap-5 xl:grid-cols-[minmax(0,1.7fr)_minmax(300px,1fr)]"
+        >
+            <div
+                class="rounded-xl border border-zinc-200 bg-white p-4 dark:border-[#25292d] dark:bg-[#111315]"
             >
-                <div class="flex items-center justify-between gap-3">
-                    <span
-                        class="grid size-9 place-items-center rounded-lg bg-violet-500/10 text-violet-600 dark:text-violet-300"
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                        <h2 class="font-semibold">Delivery trend</h2>
+                        <p class="mt-0.5 text-xs text-zinc-500">
+                            Submitted, delivered, and failed messages in the
+                            selected period.
+                        </p>
+                    </div>
+                    <div
+                        class="flex items-center gap-3 font-mono text-[10px] text-zinc-500"
                     >
-                        <Inbox class="size-4" />
-                    </span>
-                    <ArrowUpRight
-                        class="size-4 text-zinc-400 transition group-hover:text-zinc-700 dark:group-hover:text-zinc-200"
-                    />
+                        <span class="flex items-center gap-1.5"
+                            ><i class="size-2 rounded-full bg-teal-500"></i
+                            >submitted</span
+                        >
+                        <span class="flex items-center gap-1.5"
+                            ><i class="size-2 rounded-full bg-emerald-300"></i
+                            >delivered</span
+                        >
+                        <span class="flex items-center gap-1.5"
+                            ><i class="size-2 rounded-full bg-red-400"></i
+                            >failed</span
+                        >
+                    </div>
                 </div>
-                <div class="mt-4 text-2xl font-semibold">{{ inboxUnread }}</div>
-                <div class="mt-1 text-sm font-medium">Unread conversations</div>
-                <p class="mt-1 text-xs text-zinc-500">
-                    Messages that may need a reply.
-                </p>
-            </Link>
-
-            <Link
-                :href="sectionUrl('outbound')"
-                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315] dark:hover:border-zinc-600"
-            >
-                <div class="flex items-center justify-between gap-3">
-                    <span
-                        class="grid size-9 place-items-center rounded-lg bg-teal-500/10 text-teal-700 dark:text-teal-300"
+                <div
+                    class="mt-5 grid h-40 grid-cols-6 items-end gap-2 sm:grid-cols-8"
+                >
+                    <div
+                        v-for="point in dashboard.trend"
+                        :key="point.label"
+                        class="group flex h-full min-w-0 flex-col justify-end gap-1"
                     >
-                        <Send class="size-4" />
-                    </span>
-                    <ArrowUpRight
-                        class="size-4 text-zinc-400 transition group-hover:text-zinc-700 dark:group-hover:text-zinc-200"
-                    />
+                        <div
+                            class="relative flex min-h-1 flex-1 items-end overflow-hidden rounded-t-md bg-zinc-100 dark:bg-zinc-800/70"
+                        >
+                            <div
+                                class="absolute inset-x-0 bottom-0 bg-teal-500/35 transition group-hover:bg-teal-500/50"
+                                :style="{
+                                    height: `${Math.max(4, (point.sent / maxTrendValue) * 100)}%`,
+                                }"
+                            ></div>
+                            <div
+                                class="absolute inset-x-0 bottom-0 bg-emerald-400/70"
+                                :style="{
+                                    height: `${(point.delivered / maxTrendValue) * 100}%`,
+                                }"
+                            ></div>
+                            <div
+                                v-if="point.failed"
+                                class="absolute inset-x-0 top-0 h-1 bg-red-400"
+                            ></div>
+                        </div>
+                        <div
+                            class="truncate text-center font-mono text-[9px] text-zinc-400"
+                        >
+                            {{ point.label }}
+                        </div>
+                        <div
+                            class="text-center font-mono text-[9px] text-zinc-500"
+                        >
+                            {{ point.sent }}
+                        </div>
+                    </div>
                 </div>
-                <div class="mt-4 text-2xl font-semibold">
-                    {{ emails.length }}
-                </div>
-                <div class="mt-1 text-sm font-medium">
-                    Outbound in this view
-                </div>
-                <p class="mt-1 text-xs text-zinc-500">
-                    All delivery states in the selected period.
-                </p>
-            </Link>
+            </div>
 
-            <Link
-                :href="sectionUrl(sourceReady ? 'source' : 'setup')"
-                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315] dark:hover:border-zinc-600"
+            <div
+                class="rounded-xl border border-zinc-200 bg-white p-4 dark:border-[#25292d] dark:bg-[#111315]"
             >
-                <div class="flex items-center justify-between gap-3">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <h2 class="font-semibold">Sending readiness</h2>
+                        <p class="mt-0.5 text-xs text-zinc-500">
+                            Provider, domains, inbound, and quota.
+                        </p>
+                    </div>
                     <span
                         class="grid size-9 place-items-center rounded-lg"
                         :class="
-                            sourceReady
-                                ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
-                                : 'bg-amber-500/10 text-amber-600 dark:text-amber-300'
+                            dashboard.configuration.source_ready
+                                ? 'bg-emerald-500/10 text-emerald-600'
+                                : 'bg-amber-500/10 text-amber-600'
                         "
                     >
-                        <CheckCircle2 v-if="sourceReady" class="size-4" />
+                        <CheckCircle2
+                            v-if="dashboard.configuration.source_ready"
+                            class="size-4"
+                        />
                         <AlertTriangle v-else class="size-4" />
                     </span>
-                    <ArrowUpRight
-                        class="size-4 text-zinc-400 transition group-hover:text-zinc-700 dark:group-hover:text-zinc-200"
-                    />
                 </div>
-                <div class="mt-4 text-lg font-semibold">
-                    {{ sourceReady ? 'Ready to send' : 'Setup required' }}
+                <div class="mt-4 grid gap-2">
+                    <Link
+                        :href="sectionUrl('source')"
+                        class="flex items-center gap-3 rounded-lg bg-zinc-50 px-3 py-2.5 hover:bg-zinc-100 dark:bg-[#16191c] dark:hover:bg-[#1b1f23]"
+                    >
+                        <Server class="size-4 text-teal-600" /><span
+                            class="min-w-0 flex-1 text-xs"
+                            ><b class="block truncate">{{
+                                dashboard.configuration.provider
+                            }}</b
+                            ><span class="text-zinc-500"
+                                >Email provider</span
+                            ></span
+                        ><ArrowUpRight class="size-3.5 text-zinc-400" />
+                    </Link>
+                    <Link
+                        :href="sectionUrl('identities')"
+                        class="flex items-center gap-3 rounded-lg bg-zinc-50 px-3 py-2.5 hover:bg-zinc-100 dark:bg-[#16191c] dark:hover:bg-[#1b1f23]"
+                    >
+                        <Globe2 class="size-4 text-violet-500" /><span
+                            class="min-w-0 flex-1 text-xs"
+                            ><b class="block"
+                                >{{
+                                    dashboard.configuration.verified_domains
+                                }}/{{
+                                    dashboard.configuration.domains
+                                }}
+                                verified</b
+                            ><span class="text-zinc-500"
+                                >Sending domains ·
+                                {{ dashboard.configuration.inbound_domains }}
+                                inbound</span
+                            ></span
+                        ><ArrowUpRight class="size-3.5 text-zinc-400" />
+                    </Link>
+                    <div
+                        class="rounded-lg bg-zinc-50 px-3 py-2.5 dark:bg-[#16191c]"
+                    >
+                        <div
+                            class="flex items-center justify-between gap-3 text-xs"
+                        >
+                            <span class="flex items-center gap-2"
+                                ><Activity class="size-4 text-blue-500" /><b
+                                    >Provider quota</b
+                                ></span
+                            ><span
+                                class="font-mono text-[10px] text-zinc-500"
+                                >{{
+                                    quotaPercent === null
+                                        ? 'not synced'
+                                        : `${quotaPercent}% used`
+                                }}</span
+                            >
+                        </div>
+                        <div
+                            class="mt-2 h-1.5 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700"
+                        >
+                            <div
+                                class="h-full rounded-full bg-blue-500"
+                                :style="{ width: `${quotaPercent ?? 0}%` }"
+                            ></div>
+                        </div>
+                    </div>
                 </div>
-                <div class="mt-1 text-sm font-medium">Email provider</div>
+            </div>
+        </section>
+
+        <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <Link
+                :href="sectionUrl('inbox')"
+                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-violet-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315]"
+            >
+                <div class="flex items-center justify-between">
+                    <span
+                        class="grid size-9 place-items-center rounded-lg bg-violet-500/10 text-violet-600"
+                        ><Inbox class="size-4" /></span
+                    ><ArrowUpRight class="size-4 text-zinc-400" />
+                </div>
+                <div class="mt-4 text-2xl font-semibold">
+                    {{ dashboard.inbox.open }}
+                </div>
+                <div class="mt-1 text-sm font-medium">Open conversations</div>
                 <p class="mt-1 text-xs text-zinc-500">
-                    {{
-                        sourceReady
-                            ? 'Provider and domain are ready.'
-                            : 'Finish the required sending setup.'
-                    }}
+                    {{ dashboard.inbox.unread }} unread ·
+                    {{ dashboard.inbox.pending }} pending
+                </p>
+            </Link>
+            <Link
+                :href="sectionUrl('inbox', { assigned: 'mine' })"
+                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-teal-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315]"
+            >
+                <div class="flex items-center justify-between">
+                    <span
+                        class="grid size-9 place-items-center rounded-lg bg-teal-500/10 text-teal-700"
+                        ><UserRoundCheck class="size-4" /></span
+                    ><ArrowUpRight class="size-4 text-zinc-400" />
+                </div>
+                <div class="mt-4 text-2xl font-semibold">
+                    {{ dashboard.inbox.mine }}
+                </div>
+                <div class="mt-1 text-sm font-medium">Assigned to me</div>
+                <p class="mt-1 text-xs text-zinc-500">
+                    Your active inbox workload.
+                </p>
+            </Link>
+            <Link
+                :href="sectionUrl('inbox', { assigned: 'unassigned' })"
+                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-amber-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315]"
+            >
+                <div class="flex items-center justify-between">
+                    <span
+                        class="grid size-9 place-items-center rounded-lg bg-amber-500/10 text-amber-700"
+                        ><CircleDot class="size-4" /></span
+                    ><ArrowUpRight class="size-4 text-zinc-400" />
+                </div>
+                <div class="mt-4 text-2xl font-semibold">
+                    {{ dashboard.inbox.unassigned }}
+                </div>
+                <div class="mt-1 text-sm font-medium">Unassigned</div>
+                <p class="mt-1 text-xs text-zinc-500">
+                    {{ dashboard.inbox.urgent }} urgent conversation{{
+                        dashboard.inbox.urgent === 1 ? '' : 's'
+                    }}.
+                </p>
+            </Link>
+            <Link
+                :href="sectionUrl('inbox', { mailbox: 'snoozed' })"
+                class="group rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-blue-300 hover:shadow-sm dark:border-[#25292d] dark:bg-[#111315]"
+            >
+                <div class="flex items-center justify-between">
+                    <span
+                        class="grid size-9 place-items-center rounded-lg bg-blue-500/10 text-blue-600"
+                        ><Clock3 class="size-4" /></span
+                    ><ArrowUpRight class="size-4 text-zinc-400" />
+                </div>
+                <div class="mt-4 text-2xl font-semibold">
+                    {{ dashboard.inbox.snoozed }}
+                </div>
+                <div class="mt-1 text-sm font-medium">Snoozed</div>
+                <p class="mt-1 text-xs text-zinc-500">
+                    Conversations scheduled to return.
                 </p>
             </Link>
         </section>
@@ -222,9 +568,8 @@ function sectionUrl(section: string): string {
                     <Link
                         :href="sectionUrl('outbound')"
                         class="text-xs font-semibold text-teal-700 hover:underline dark:text-teal-300"
+                        >View all {{ dashboard.outbound.total }}</Link
                     >
-                        View all
-                    </Link>
                 </div>
                 <div
                     v-if="recentOutbound.length"
@@ -233,7 +578,7 @@ function sectionUrl(section: string): string {
                     <Link
                         v-for="email in recentOutbound"
                         :key="email.id"
-                        :href="`${sectionUrl('outbound')}?q=${encodeURIComponent(email.id)}`"
+                        :href="sectionUrl('outbound', { q: email.id })"
                         class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-3 transition hover:bg-zinc-50 dark:hover:bg-[#16191c]"
                     >
                         <div class="min-w-0">
@@ -274,15 +619,14 @@ function sectionUrl(section: string): string {
                     <div>
                         <h2 class="font-semibold">Recent conversations</h2>
                         <p class="mt-0.5 text-xs text-zinc-500">
-                            Inbox threads with the latest activity.
+                            Ownership and priority at a glance.
                         </p>
                     </div>
                     <Link
                         :href="sectionUrl('inbox')"
                         class="text-xs font-semibold text-teal-700 hover:underline dark:text-teal-300"
+                        >Open Inbox</Link
                     >
-                        Open Inbox
-                    </Link>
                 </div>
                 <div
                     v-if="recentThreads.length"
@@ -291,7 +635,9 @@ function sectionUrl(section: string): string {
                     <Link
                         v-for="thread in recentThreads"
                         :key="thread.public_id"
-                        :href="`${sectionUrl('inbox')}?thread=${encodeURIComponent(thread.public_id)}`"
+                        :href="
+                            sectionUrl('inbox', { thread: thread.public_id })
+                        "
                         class="grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 transition hover:bg-zinc-50 dark:hover:bg-[#16191c]"
                     >
                         <span
@@ -303,10 +649,19 @@ function sectionUrl(section: string): string {
                             "
                         />
                         <div class="min-w-0">
-                            <div class="truncate text-sm font-medium">
-                                {{ thread.subject || '(no subject)' }}
+                            <div class="flex min-w-0 items-center gap-2">
+                                <span class="truncate text-sm font-medium">{{
+                                    thread.subject || '(no subject)'
+                                }}</span
+                                ><span
+                                    v-if="thread.priority === 'urgent'"
+                                    class="rounded bg-red-500/10 px-1.5 py-0.5 font-mono text-[9px] text-red-600"
+                                    >urgent</span
+                                >
                             </div>
                             <div class="mt-0.5 truncate text-xs text-zinc-500">
+                                {{ thread.assigned_to || 'Unassigned' }} ·
+                                {{ thread.status }} ·
                                 {{
                                     thread.snippet ||
                                     thread.participants.join(', ')
@@ -329,48 +684,61 @@ function sectionUrl(section: string): string {
             </div>
         </section>
 
-        <section
-            class="flex flex-wrap items-center gap-4 rounded-xl border p-4"
-            :class="
-                systemReady
-                    ? 'border-zinc-200 bg-white dark:border-[#25292d] dark:bg-[#111315]'
-                    : 'border-amber-200 bg-amber-50 dark:border-amber-500/20 dark:bg-amber-500/10'
-            "
-        >
-            <span
-                class="grid size-9 place-items-center rounded-lg"
-                :class="
-                    systemReady
-                        ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
-                        : 'bg-amber-500/10 text-amber-600 dark:text-amber-300'
-                "
+        <section class="grid gap-3 sm:grid-cols-3">
+            <Link
+                :href="sectionUrl('webhooks')"
+                class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-[#25292d] dark:bg-[#111315]"
+                ><span
+                    class="grid size-9 place-items-center rounded-lg bg-violet-500/10 text-violet-600"
+                    ><Webhook class="size-4" /></span
+                ><span class="min-w-0 flex-1"
+                    ><b class="block text-sm"
+                        >{{ dashboard.developer.active_webhooks }} active
+                        webhooks</b
+                    ><span class="text-xs text-zinc-500"
+                        >{{ dashboard.developer.failing_webhooks }} failures
+                        this period</span
+                    ></span
+                ><ArrowUpRight class="size-4 text-zinc-400"
+            /></Link>
+            <Link
+                :href="sectionUrl('api-keys')"
+                class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-[#25292d] dark:bg-[#111315]"
+                ><span
+                    class="grid size-9 place-items-center rounded-lg bg-blue-500/10 text-blue-600"
+                    ><KeyRound class="size-4" /></span
+                ><span class="min-w-0 flex-1"
+                    ><b class="block text-sm"
+                        >{{ dashboard.developer.api_keys }} API keys</b
+                    ><span class="text-xs text-zinc-500"
+                        >{{ dashboard.developer.expiring_api_keys }} expiring
+                        soon</span
+                    ></span
+                ><ArrowUpRight class="size-4 text-zinc-400"
+            /></Link>
+            <div
+                class="flex items-center gap-3 rounded-xl border border-zinc-200 bg-white p-4 dark:border-[#25292d] dark:bg-[#111315]"
             >
-                <CheckCircle2 v-if="systemReady" class="size-4" />
-                <AlertTriangle v-else class="size-4" />
-            </span>
-            <div class="min-w-0 flex-1">
-                <h2 class="text-sm font-semibold">System health</h2>
-                <p class="mt-0.5 text-xs text-zinc-500">
-                    Queue worker
-                    {{
-                        system.worker_alive
-                            ? `running · ${system.worker_last_seen || 'recently seen'}`
-                            : 'not detected'
-                    }}
-                    · Scheduler
-                    {{
-                        system.scheduler_alive
-                            ? `running · ${system.scheduler_last_seen || 'recently seen'}`
-                            : 'not detected'
-                    }}
-                </p>
+                <span
+                    class="grid size-9 place-items-center rounded-lg"
+                    :class="
+                        system.worker_alive && system.scheduler_alive
+                            ? 'bg-emerald-500/10 text-emerald-600'
+                            : 'bg-amber-500/10 text-amber-600'
+                    "
+                    ><Server class="size-4" /></span
+                ><span class="min-w-0 flex-1"
+                    ><b class="block text-sm">Infrastructure</b
+                    ><span class="text-xs text-zinc-500"
+                        >Worker
+                        {{ system.worker_alive ? 'online' : 'offline' }} ·
+                        Scheduler
+                        {{
+                            system.scheduler_alive ? 'online' : 'offline'
+                        }}</span
+                    ></span
+                >
             </div>
-            <span
-                v-if="system.stuck_queued"
-                class="rounded-md bg-amber-500/10 px-2.5 py-1 font-mono text-xs text-amber-700 dark:text-amber-300"
-            >
-                {{ system.stuck_queued }} queued
-            </span>
         </section>
     </div>
 </template>

--- a/resources/js/components/GlobalRail.vue
+++ b/resources/js/components/GlobalRail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Link, usePage } from '@inertiajs/vue3';
+import { Link, router, usePage } from '@inertiajs/vue3';
 import {
     Activity,
     AlertTriangle,
@@ -10,13 +10,17 @@ import {
     Inbox,
     KeyRound,
     LayoutDashboard,
+    LogOut,
     Settings2,
     SlidersHorizontal,
+    UserRound,
     Users,
     Webhook,
     X,
 } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
+import { logout } from '@/routes';
+import { edit as editProfile } from '@/routes/profile';
 
 type ProjectOption = {
     name: string;
@@ -37,12 +41,14 @@ const props = withDefaults(
         counts?: Record<string, number>;
         inboxUnread?: number;
         buildLabel?: string;
+        accountActive?: boolean;
     }>(),
     {
         projects: () => [],
         counts: () => ({}),
         inboxUnread: 0,
         buildLabel: '',
+        accountActive: false,
     },
 );
 
@@ -51,6 +57,10 @@ const page = usePage<{
 }>();
 const projectMenuOpen = ref(false);
 const mobileMenuOpen = ref(false);
+
+function handleLogout(): void {
+    router.flushAll();
+}
 
 const userInitials = computed(() =>
     page.props.auth.user.name
@@ -304,8 +314,12 @@ const mobileItems = computed(() => [
 
         <div class="border-t border-zinc-200 p-3 dark:border-[#1d2125]">
             <Link
-                href="/settings/profile"
+                :href="editProfile()"
                 class="flex items-center gap-3 rounded-lg p-2 transition hover:bg-zinc-100 dark:hover:bg-[#16191c]"
+                :class="{
+                    'bg-zinc-100 ring-1 ring-zinc-200 dark:bg-[#16191c] dark:ring-[#25292d]':
+                        accountActive,
+                }"
             >
                 <span
                     class="grid size-8 shrink-0 place-items-center rounded-full bg-gradient-to-br from-violet-300 to-teal-300 font-mono text-[10px] font-semibold text-[#0b0c0d]"
@@ -320,6 +334,16 @@ const mobileItems = computed(() => [
                         {{ page.props.auth.user.email }}
                     </span>
                 </span>
+            </Link>
+            <Link
+                :href="logout()"
+                as="button"
+                class="mt-1 flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-xs font-semibold text-zinc-500 transition hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-500/10 dark:hover:text-red-300"
+                data-test="global-logout-button"
+                @click="handleLogout"
+            >
+                <LogOut class="size-3.5" />
+                Log out
             </Link>
             <p
                 v-if="buildLabel"
@@ -396,6 +420,28 @@ const mobileItems = computed(() => [
                 </Link>
             </section>
         </nav>
+
+        <Link
+            :href="editProfile()"
+            class="mt-5 flex min-h-11 items-center gap-3 rounded-xl border border-zinc-200 bg-white px-3 text-sm font-semibold text-zinc-700 dark:border-[#25292d] dark:bg-[#111315] dark:text-zinc-200"
+            @click="mobileMenuOpen = false"
+        >
+            <UserRound class="size-4 text-teal-600 dark:text-teal-300" />
+            <span class="min-w-0 flex-1">Account settings</span>
+            <span class="truncate text-xs font-normal text-zinc-500">
+                {{ page.props.auth.user.name }}
+            </span>
+        </Link>
+        <Link
+            :href="logout()"
+            as="button"
+            class="mt-2 flex min-h-11 w-full items-center gap-3 rounded-xl border border-red-200 bg-red-50 px-3 text-sm font-semibold text-red-700 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-300"
+            data-test="mobile-logout-button"
+            @click="handleLogout"
+        >
+            <LogOut class="size-4" />
+            Log out
+        </Link>
     </section>
 
     <nav

--- a/resources/js/components/landing/LandingDashboardPreview.vue
+++ b/resources/js/components/landing/LandingDashboardPreview.vue
@@ -3,6 +3,8 @@ import {
     Activity,
     AlertTriangle,
     Copy,
+    FileText,
+    Inbox,
     KeyRound,
     MailCheck,
     Power,
@@ -188,15 +190,17 @@ const metrics = computed(() => [
 ]);
 
 const navItems: NavItem[] = [
-    { label: 'Activity', icon: Activity, count: '16' },
-    { label: 'Sent', icon: Send, count: '16' },
+    { label: 'Dashboard', icon: Activity },
+    { label: 'Inbox', icon: Inbox, count: '4' },
+    { label: 'Outbound', icon: Send, count: '16' },
     { label: 'Bounces', icon: Activity, count: '2' },
     { label: 'Complaints', icon: AlertTriangle, count: '1' },
     { label: 'Suppressions', icon: Power, count: '2' },
 ];
 
 const configItems: NavItem[] = [
-    { label: 'Identities', icon: MailCheck },
+    { label: 'Templates', icon: FileText },
+    { label: 'Domains', icon: MailCheck },
     { label: 'Webhooks', icon: Activity },
     { label: 'API keys', icon: KeyRound },
 ];
@@ -325,7 +329,7 @@ onBeforeUnmount(() => {
             </div>
             <div class="preview-crumb">
                 <span>Project</span><i>/</i><b>harborlight</b><i>/</i
-                ><strong>Activity</strong>
+                ><strong>Outbound</strong>
             </div>
             <button
                 class="preview-search"
@@ -367,7 +371,7 @@ onBeforeUnmount(() => {
                         v-for="item in navItems"
                         :key="item.label"
                         type="button"
-                        :class="{ active: item.label === 'Activity' }"
+                        :class="{ active: item.label === 'Outbound' }"
                     >
                         <component :is="item.icon" />
                         <b>{{ item.label }}</b>
@@ -389,13 +393,13 @@ onBeforeUnmount(() => {
                     <span>Stored sends</span>
                     <strong>209,340</strong>
                     <div><i></i></div>
-                    <small>Last 30 days · SES quota sync optional</small>
+                    <small>Last 30 days · provider quota synced</small>
                 </div>
             </aside>
 
             <main class="preview-main">
                 <section class="preview-titlebar">
-                    <h3>Activity</h3>
+                    <h3>Outbound</h3>
                     <span><i></i> live</span>
                     <button type="button">Export</button>
                 </section>

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -1,160 +1,164 @@
 <script setup lang="ts">
 import { Link, usePage } from '@inertiajs/vue3';
-import { Activity, KeyRound, Palette, ShieldCheck, UserRound } from 'lucide-vue-next';
+import { Palette, ShieldCheck, UserRound } from 'lucide-vue-next';
 import { computed } from 'vue';
-import AppLogoIcon from '@/components/AppLogoIcon.vue';
+import GlobalRail from '@/components/GlobalRail.vue';
 import { Toaster } from '@/components/ui/sonner';
 import { useCurrentUrl } from '@/composables/useCurrentUrl';
 import { dashboard } from '@/routes';
 import { edit as editAppearance } from '@/routes/appearance';
 import { edit as editProfile } from '@/routes/profile';
+import { section as projectSection } from '@/routes/projects';
 import { edit as editSecurity } from '@/routes/security';
 
-const sidebarNavItems = [
-    {
-        title: 'Profile',
-        href: editProfile(),
-        icon: UserRound,
-    },
-    {
-        title: 'Security',
-        href: editSecurity(),
-        icon: ShieldCheck,
-    },
-    {
-        title: 'Appearance',
-        href: editAppearance(),
-        icon: Palette,
-    },
-];
+type SettingsNavigation = {
+    project: {
+        name: string;
+        slug: string;
+        path: string;
+    };
+    projects: {
+        name: string;
+        slug: string;
+        environment: string;
+        provider_label: string;
+        href: string;
+        is_current: boolean;
+    }[];
+    counts: Record<string, number>;
+    inbox_unread: number;
+};
 
-const page = usePage();
-const user = computed(() => page.props.auth.user);
-const initials = computed(() =>
-    String(user.value.name ?? 'User')
-        .split(' ')
-        .map((part) => part.charAt(0))
-        .join('')
-        .slice(0, 2)
-        .toUpperCase(),
+const page = usePage<{ settingsNavigation: SettingsNavigation | null }>();
+const navigation = computed(() => page.props.settingsNavigation);
+const dashboardUrl = computed(() =>
+    navigation.value
+        ? projectSection.url({
+              project: navigation.value.project.slug,
+              section: 'activity',
+          })
+        : dashboard().url,
 );
+
+const settingsItems = [
+    { title: 'Profile', href: editProfile(), icon: UserRound },
+    { title: 'Security', href: editSecurity(), icon: ShieldCheck },
+    { title: 'Appearance', href: editAppearance(), icon: Palette },
+];
 
 const { isCurrentOrParentUrl } = useCurrentUrl();
 </script>
 
 <template>
     <div
-        class="h-screen overflow-hidden bg-[#fbfaf7] font-sans text-[13px] text-zinc-900 antialiased dark:bg-[#0b0c0d] dark:text-[#e9eaec]"
+        class="h-screen overflow-hidden bg-[#fbfaf7] pb-16 font-sans text-sm text-zinc-900 antialiased lg:pb-0 dark:bg-[#0b0c0d] dark:text-[#e9eaec]"
     >
         <div
-            class="grid h-screen min-h-0 grid-cols-[224px_minmax(0,1fr)] grid-rows-[52px_minmax(0,1fr)]"
+            class="grid h-full min-h-0 grid-cols-1 grid-rows-[60px_minmax(0,1fr)] lg:grid-rows-[64px_minmax(0,1fr)]"
+            :class="{
+                'lg:grid-cols-[248px_minmax(0,1fr)]': navigation,
+            }"
         >
+            <GlobalRail
+                v-if="navigation"
+                :project-path="navigation.project.path"
+                :project-name="navigation.project.name"
+                :project-slug="navigation.project.slug"
+                section="account"
+                :projects="navigation.projects"
+                :counts="navigation.counts"
+                :inbox-unread="navigation.inbox_unread"
+                account-active
+            />
+
             <header
-                class="col-span-2 flex h-[52px] shrink-0 items-center gap-3 border-b border-zinc-200 bg-[#fbfaf7] px-3.5 dark:border-[#1d2125] dark:bg-[#0b0c0d]"
+                class="col-start-1 row-start-1 flex min-w-0 items-center gap-3 border-b border-zinc-200 bg-[#fbfaf7] px-3 sm:px-4 dark:border-[#1d2125] dark:bg-[#0b0c0d]"
+                :class="{ 'lg:col-start-2': navigation }"
             >
                 <div
-                    class="flex h-full w-[210px] items-center gap-2 border-r border-zinc-200 pr-3 dark:border-[#1d2125]"
+                    v-if="navigation"
+                    class="flex min-w-0 items-center gap-2.5 lg:hidden"
                 >
                     <Link
-                        :href="dashboard()"
-                        class="grid size-[22px] place-items-center rounded-md bg-teal-300 text-[#0b0c0d]"
+                        :href="dashboardUrl"
+                        class="grid size-8 shrink-0 place-items-center rounded-lg bg-teal-300 font-mono text-xs font-bold text-[#07221c]"
                     >
-                        <AppLogoIcon class="size-[17px]" />
+                        L
                     </Link>
-                    >
+                    <span class="truncate text-sm font-semibold">
+                        {{ navigation.project.name }}
+                    </span>
+                </div>
+                <div v-else class="flex min-w-0 items-center gap-2.5">
                     <Link
-                        :href="dashboard()"
-                        class="font-sans text-sm font-semibold tracking-tight"
-                        >larasend</Link
+                        :href="dashboardUrl"
+                        class="grid size-8 shrink-0 place-items-center rounded-lg bg-teal-300 font-mono text-xs font-bold text-[#07221c]"
                     >
+                        L
+                    </Link>
+                    <span class="truncate text-sm font-semibold">
+                        Account settings
+                    </span>
                 </div>
 
-                <div
-                    class="flex items-center gap-2 font-sans text-[12.5px] text-zinc-500 dark:text-[#9aa0a6]"
-                >
-                    <Link
-                        :href="dashboard()"
-                        class="hover:text-zinc-950 dark:hover:text-zinc-100"
-                        >Dashboard</Link
-                    >
-                    <span class="text-zinc-400 dark:text-[#4a4f55]">/</span>
-                    <span class="font-medium text-zinc-950 dark:text-zinc-100"
-                        >Settings</span
-                    >
+                <div class="hidden min-w-0 items-center gap-2 lg:flex">
+                    <span class="truncate font-semibold">Account settings</span>
+                    <span class="text-zinc-300 dark:text-zinc-700">/</span>
+                    <span class="truncate text-xs text-zinc-500">
+                        Profile, security, and appearance
+                    </span>
                 </div>
 
                 <Link
-                    :href="dashboard()"
-                    class="ml-auto inline-flex h-8 items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 font-sans text-[12.5px] font-medium text-zinc-700 hover:bg-zinc-100 dark:border-[#1d2125] dark:bg-[#111315] dark:text-zinc-200 dark:hover:bg-[#16191c]"
+                    :href="dashboardUrl"
+                    class="ml-auto inline-flex h-8 items-center rounded-lg border border-zinc-200 bg-white px-3 text-xs font-semibold text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-950 dark:border-[#25292d] dark:bg-[#111315] dark:text-zinc-300 dark:hover:border-zinc-600 dark:hover:text-white"
                 >
-                    <Activity class="size-3.5" />
-                    Activity
+                    Back to dashboard
                 </Link>
-                <div
-                    class="grid size-[26px] place-items-center rounded-full bg-gradient-to-br from-violet-300 to-teal-300 font-mono text-[11px] font-semibold text-[#0b0c0d]"
-                >
-                    {{ initials }}
-                </div>
             </header>
 
-            <aside
-                class="relative row-start-2 flex min-h-0 flex-col border-r border-zinc-200 bg-[#fbfaf7] px-2 py-2 dark:border-[#1d2125] dark:bg-[#0b0c0d]"
+            <main
+                class="col-start-1 row-start-2 min-h-0 overflow-y-auto"
+                :class="{ 'lg:col-start-2': navigation }"
             >
-                <div class="min-h-0 flex-1 overflow-y-auto">
-                    <div
-                        class="px-2 pt-1 pb-1.5 font-mono text-[10.5px] font-medium tracking-widest text-zinc-500 uppercase dark:text-[#6c7177]"
-                    >
-                        Account
+                <div class="mx-auto w-full max-w-5xl px-4 py-5 sm:px-6 sm:py-7">
+                    <div class="mb-6">
+                        <h1 class="text-xl font-semibold tracking-tight">
+                            Account settings
+                        </h1>
+                        <p class="mt-1 text-[13px] text-zinc-500">
+                            Manage your Larasend profile, security, and local
+                            display preferences.
+                        </p>
                     </div>
-                    <nav class="space-y-0.5" aria-label="Settings">
+
+                    <nav
+                        class="mb-7 flex gap-1 overflow-x-auto border-b border-zinc-200 dark:border-[#25292d]"
+                        aria-label="Account settings"
+                    >
                         <Link
-                            v-for="item in sidebarNavItems"
+                            v-for="item in settingsItems"
                             :key="item.title"
                             :href="item.href"
-                            class="group relative flex h-7 w-full items-center gap-2.5 rounded-md px-2 text-left font-sans text-[12.5px] text-zinc-600 hover:bg-zinc-100 hover:text-zinc-950 dark:text-[#9aa0a6] dark:hover:bg-[#16191c] dark:hover:text-zinc-100"
+                            class="relative inline-flex h-10 shrink-0 items-center gap-2 px-3 text-xs font-semibold text-zinc-500 transition hover:text-zinc-950 dark:hover:text-zinc-100"
                             :class="{
-                                'bg-zinc-200/70 font-medium text-zinc-950 before:absolute before:top-1.5 before:bottom-1.5 before:-left-2 before:w-0.5 before:rounded-r before:bg-teal-300 dark:bg-[#1a1e22] dark:text-zinc-100':
+                                'text-zinc-950 after:absolute after:right-2 after:bottom-0 after:left-2 after:h-0.5 after:rounded-full after:bg-teal-400 dark:text-zinc-100':
                                     isCurrentOrParentUrl(item.href),
                             }"
                         >
                             <component :is="item.icon" class="size-3.5" />
-                            <span>{{ item.title }}</span>
+                            {{ item.title }}
                         </Link>
                     </nav>
-                </div>
 
-                <div
-                    class="rounded-lg border border-zinc-200 bg-white p-3 dark:border-[#1d2125] dark:bg-[#111315]"
-                >
-                    <div
-                        class="flex items-center gap-2 font-mono text-[11px] text-zinc-500"
+                    <section
+                        class="grid max-w-2xl gap-10 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm shadow-zinc-950/[0.02] sm:p-6 dark:border-[#25292d] dark:bg-[#111315]"
                     >
-                        <KeyRound class="size-3.5 text-teal-400" />
-                        Account settings
-                    </div>
-                    <p class="mt-2 text-[12px] leading-5 text-zinc-500">
-                        Profile, access, and local display preferences.
-                    </p>
-                </div>
-            </aside>
-
-            <main class="row-start-2 min-h-0 overflow-y-auto">
-                <div class="mx-auto w-full max-w-5xl px-6 py-7">
-                    <div class="mb-7">
-                        <h1 class="text-xl font-semibold tracking-tight">
-                            Settings
-                        </h1>
-                        <p class="mt-1 text-[13px] text-zinc-500">
-                            Manage your Larasend profile and account settings.
-                        </p>
-                    </div>
-
-                    <section class="max-w-2xl space-y-12">
                         <slot />
                     </section>
                 </div>
             </main>
         </div>
+        <Toaster />
     </div>
-    <Toaster />
 </template>

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -206,6 +206,57 @@ const props = defineProps<{
     section: string;
     filters: { q: string; range: string };
     metrics: Metric[];
+    dashboard: {
+        outbound: {
+            total: number;
+            failed: number;
+            queued: number;
+            bounced: number;
+            complained: number;
+        };
+        inbox: {
+            open: number;
+            unread: number;
+            mine: number;
+            unassigned: number;
+            urgent: number;
+            pending: number;
+            snoozed: number;
+        };
+        configuration: {
+            provider: string;
+            source_ready: boolean;
+            domains: number;
+            verified_domains: number;
+            inbound_domains: number;
+            quota: {
+                sent: number;
+                limit: number | null;
+                sentLast24Hours: number | null;
+                checkedAt: string | null;
+            };
+        };
+        developer: {
+            active_webhooks: number;
+            failing_webhooks: number;
+            api_keys: number;
+            expiring_api_keys: number;
+        };
+        trend: {
+            label: string;
+            sent: number;
+            delivered: number;
+            failed: number;
+        }[];
+        attention: {
+            key: string;
+            label: string;
+            description: string;
+            count: number;
+            section: string;
+            tone: string;
+        }[];
+    } | null;
     bounceMetrics: BounceMetric[];
     bounceQueue: BounceQueueRow[];
     emails: EmailRow[];
@@ -220,6 +271,9 @@ const props = defineProps<{
         direction: string | null;
         message_count: number;
         unread: boolean;
+        status: string;
+        priority: string;
+        assigned_to: string | null;
         last_activity_at: string | null;
         last_activity_human: string | null;
     }[];
@@ -347,8 +401,16 @@ const buildLabel = computed(() => {
     const build = page.props.build as
         | { version?: string | null; sha?: string | null }
         | undefined;
-    const version = build?.version || 'dev';
+    const version = build?.version || null;
     const sha = build?.sha ? build.sha.slice(0, 7) : null;
+
+    if (!version && !sha) {
+        return '';
+    }
+
+    if (!version) {
+        return sha ?? '';
+    }
 
     return sha ? `v${version} · ${sha}` : `v${version}`;
 });
@@ -1842,7 +1904,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                 </section>
 
                 <div
-                    v-if="section === 'activity'"
+                    v-if="section === 'activity' && dashboard"
                     class="min-h-0 flex-1 overflow-auto p-5"
                 >
                     <DashboardPanel
@@ -1850,8 +1912,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                         :metrics="metrics"
                         :emails="emails"
                         :recent-threads="recentThreads"
-                        :inbox-unread="inboxUnread ?? 0"
-                        :source-ready="Boolean(source?.can_send)"
+                        :dashboard="dashboard"
                         :system="system"
                     />
                 </div>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -58,24 +58,34 @@ const landingStyle = computed(() => ({
 
 const featureCards = [
     {
-        title: '"Where did that email go?"',
-        body: 'Never again. Every send captures the request, SES message ID, recipients, headers, tags, timeline, raw MIME, and a rendered preview on one screen.',
+        title: 'Send from the tools you already use',
+        body: 'Use the Laravel transport, transactional API, dashboard composer, or reusable templates. Larasend keeps every request and delivery event together.',
         accent: 'mint',
     },
     {
-        title: '"Did DNS actually propagate?"',
-        body: 'Add an SES identity, copy DKIM records, re-check DNS with one click, and see exactly what is still missing before production traffic moves.',
+        title: 'Turn replies into team conversations',
+        body: 'Receive inbound mail, reply and forward with attachments, assign owners, add notes and tags, set priority, snooze work, and keep the full thread in one place.',
         accent: 'blue',
     },
     {
-        title: '"Do we have to rewrite our mail code?"',
-        body: 'No. Set MAIL_MAILER=larasend and every mailable, notification, and queued send you already have flows through Larasend unchanged.',
+        title: 'Bring SES or Cloudflare',
+        body: 'Connect Amazon SES or Cloudflare Email Sending. Credentials, sending domains, DNS verification, quota, and provider capabilities stay visible.',
         accent: 'violet',
     },
     {
-        title: '"Why did our webhook miss that bounce?"',
-        body: 'SES events are signature-verified, normalized, retried, and visible with request status, latency, endpoint health, and failure history.',
+        title: 'Protect your deliverability',
+        body: 'Investigate bounces and complaints, maintain suppressions, monitor rates, and trace each message from submission through its latest provider event.',
         accent: 'amber',
+    },
+    {
+        title: 'Operate with fewer blind spots',
+        body: 'See failed sends, inbox workload, domain readiness, webhook failures, quota, queue workers, and scheduler health from one operational dashboard.',
+        accent: 'mint',
+    },
+    {
+        title: 'Give every project a clean boundary',
+        body: 'Separate environments and applications with projects, scoped API keys, workspace roles, domains, templates, and retention controls.',
+        accent: 'blue',
     },
 ];
 
@@ -106,18 +116,18 @@ const setupSteps = [
     ],
     [
         '02',
-        'Connect Amazon SES',
-        'Paste SES credentials for sending, quota reads, identity checks, and event configuration.',
+        'Choose your sending provider',
+        'Connect Amazon SES with IAM credentials or an instance role, or connect Cloudflare Email Sending with an API token.',
     ],
     [
         '03',
-        'Verify your domain',
-        'Copy DKIM, SPF, DMARC, and bounce records into Route 53 or your DNS provider.',
+        'Onboard your domain',
+        'Create and verify the DNS records Larasend shows. Cloudflare-managed domains can be provisioned automatically.',
     ],
     [
         '04',
-        'Create an API key',
-        'Reveal the key once, copy it into your Laravel apps, and start sending transactional mail.',
+        'Send, receive, and collaborate',
+        'Create an API key, send a test message, enable inbound routing, and bring your team into the shared inbox.',
     ],
 ];
 
@@ -156,7 +166,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <Head title="The email dashboard AWS never built">
+    <Head title="Self-hosted email operations for product teams">
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
             rel="preconnect"
@@ -236,20 +246,22 @@ onBeforeUnmount(() => {
                 <div class="eyebrow reveal">
                     <span class="pill">open source</span>
                     <span class="pulse-dot"></span>
-                    <span>Self-hosted · Powered by your own AWS SES</span>
+                    <span
+                        >Self-hosted · Amazon SES or Cloudflare Email
+                        Sending</span
+                    >
                 </div>
 
                 <h1 class="reveal hero-title">
-                    <span class="line">The email dashboard</span>
-                    <span class="line accent-line">AWS never built.</span>
+                    <span class="line">Send, receive, and run</span>
+                    <span class="line accent-line">email on your terms.</span>
                 </h1>
 
                 <p class="lede reveal">
-                    SES gives you cheap, reliable sending — and nothing else. No
-                    dashboard, no delivery timeline, no content previews, no API
-                    keys, no suppression list. Larasend is the missing control
-                    plane: self-hosted, Laravel-native, and running entirely on
-                    your own AWS account.
+                    Larasend is the open-source email operations layer for
+                    product teams. Send through SES or Cloudflare, receive
+                    replies in a collaborative inbox, monitor deliverability,
+                    and keep your email data on infrastructure you control.
                 </p>
 
                 <div class="install-cmd reveal">
@@ -294,13 +306,13 @@ onBeforeUnmount(() => {
                     <div style="--stagger: 0ms">
                         <strong>~$0.10</strong>
                         <span
-                            >per 1,000 emails — SES pricing, we charge
-                            nothing</span
+                            >per 1,000 emails with SES — Larasend adds no
+                            sending markup</span
                         >
                     </div>
                     <div style="--stagger: 70ms">
                         <strong>5 min</strong>
-                        <span>from docker compose up to dashboard</span>
+                        <span>from Docker Compose to guided setup</span>
                     </div>
                     <div style="--stagger: 140ms">
                         <strong>100%</strong>
@@ -327,9 +339,9 @@ onBeforeUnmount(() => {
                     <span>Invoices</span>
                     <span>Product notifications</span>
                     <span>Lifecycle email</span>
-                    <span>Webhook audits</span>
+                    <span>Team inbox</span>
                     <span>Suppression lists</span>
-                    <span>SES quota</span>
+                    <span>Provider quota</span>
                     <span>DKIM checks</span>
                     <span>Raw MIME</span>
                     <span>Receipts</span>
@@ -337,9 +349,9 @@ onBeforeUnmount(() => {
                     <span>Invoices</span>
                     <span>Product notifications</span>
                     <span>Lifecycle email</span>
-                    <span>Webhook audits</span>
+                    <span>Team inbox</span>
                     <span>Suppression lists</span>
-                    <span>SES quota</span>
+                    <span>Provider quota</span>
                     <span>DKIM checks</span>
                     <span>Raw MIME</span>
                 </div>
@@ -348,11 +360,11 @@ onBeforeUnmount(() => {
             <section id="features" class="section container">
                 <div class="section-head reveal">
                     <span>Built for product teams</span>
-                    <h2>Every send visible. Every event accountable.</h2>
+                    <h2>One place to send, receive, and operate email.</h2>
                     <p>
-                        Larasend gives your team the pieces raw SES does not:
-                        API keys, activity, previews, domains, webhook retries,
-                        and a Laravel-first integration path.
+                        Start with a Laravel-native sending API, then manage the
+                        full operational loop: inbound replies, team ownership,
+                        delivery health, domains, webhooks, and access.
                     </p>
                 </div>
 
@@ -387,7 +399,8 @@ onBeforeUnmount(() => {
                         <li>Symfony Mailer transport for Laravel mail.</li>
                         <li>Direct client for transactional API sends.</li>
                         <li>
-                            Clear failures when SES rejects or throttles mail.
+                            Clear failures when a provider rejects or throttles
+                            mail.
                         </li>
                     </ul>
                 </div>
@@ -431,10 +444,11 @@ Larasend::emails()->send([
                         reputation management.
                     </p>
                     <p>
-                        We didn't want to run a mail server. We wanted SES with
-                        a real product around it. So we built Larasend, ran it
-                        in production for our own transactional email, and now
-                        it's yours.
+                        We didn't want to run a mail server. We wanted the
+                        economics and control of infrastructure providers with
+                        the workflow of a real product. So we built Larasend,
+                        ran it for our own transactional email, and opened it
+                        up.
                     </p>
                 </div>
             </section>
@@ -443,11 +457,11 @@ Larasend::emails()->send([
                 <div class="section-head reveal">
                     <span>Install to first send</span>
                     <h2>
-                        Production setup without a weekend in the AWS console.
+                        Production setup without a weekend in provider consoles.
                     </h2>
                     <p>
                         Larasend stays self-hosted first. Bring your database,
-                        your AWS account, and your sending domain.
+                        an SES or Cloudflare account, and your sending domain.
                     </p>
                 </div>
 
@@ -470,13 +484,13 @@ Larasend::emails()->send([
                     <div class="compare-title">
                         <span>Why Larasend</span>
                         <h2>
-                            The dashboard of a hosted API. The ownership of raw
-                            SES.
+                            The workflow of a hosted platform. The ownership of
+                            self-hosted infrastructure.
                         </h2>
                     </div>
                     <div class="compare-table">
                         <div>
-                            <b>Capability</b><b>Raw SES</b
+                            <b>Capability</b><b>Raw provider</b
                             ><b>Hosted email APIs</b><b>Larasend</b>
                         </div>
                         <div>
@@ -487,6 +501,16 @@ Larasend::emails()->send([
                             <span>Laravel mail transport</span><em>Build it</em
                             ><em>SDK migration</em
                             ><strong>One line of .env</strong>
+                        </div>
+                        <div>
+                            <span>Shared inbox and replies</span
+                            ><em>Build it</em><em>Usually separate</em
+                            ><strong>Included</strong>
+                        </div>
+                        <div>
+                            <span>SES and Cloudflare support</span
+                            ><em>One provider</em><em>Vendor platform</em
+                            ><strong>Choose either</strong>
                         </div>
                         <div>
                             <span>Webhook retries and logs</span
@@ -518,8 +542,8 @@ Larasend::emails()->send([
                     </h2>
                     <p>
                         Larasend is designed for teams that want a polished mail
-                        API and dashboard running on their own SES account,
-                        their own storage, and a codebase they can inspect.
+                        API, shared inbox, and operational dashboard running on
+                        their own provider accounts, storage, and codebase.
                     </p>
                     <div class="cta-row">
                         <a
@@ -552,12 +576,13 @@ Larasend::emails()->send([
                         <b>savvyagents / larasend</b>
                     </div>
                     <p>
-                        Open-source SES dashboard, sending API, webhook router,
-                        and Laravel mailer package.
+                        Open-source sending API, collaborative inbox,
+                        deliverability console, and Laravel mailer package.
                     </p>
                     <ul>
                         <li><span></span> Vue + Inertia dashboard</li>
-                        <li><span></span> Amazon SES v2 sending</li>
+                        <li><span></span> Amazon SES and Cloudflare sending</li>
+                        <li><span></span> Inbound email and shared inbox</li>
                         <li><span></span> Docker Compose install</li>
                         <li><span></span> Laravel package integration</li>
                     </ul>
@@ -565,11 +590,10 @@ Larasend::emails()->send([
             </section>
 
             <section id="cta" class="final-cta reveal container">
-                <h2>From zero to sending in one command.</h2>
+                <h2>Own the whole email workflow.</h2>
                 <p>
-                    Pull the compose file, add your SES credentials, and start
-                    sending transactional email with the observability your team
-                    needs.
+                    Pull the compose file, connect your provider, and give your
+                    team one place to send, receive, investigate, and respond.
                 </p>
                 <div class="install-cmd">
                     <code>{{ installCommand }}</code>
@@ -619,8 +643,8 @@ Larasend::emails()->send([
                         ><span>larasend</span>
                     </div>
                     <p>
-                        Open-source email infrastructure for Laravel teams
-                        running on Amazon SES.
+                        Open-source email operations for Laravel teams using
+                        Amazon SES or Cloudflare Email Sending.
                     </p>
                 </div>
                 <a href="#features">Features</a>
@@ -643,7 +667,7 @@ Larasend::emails()->send([
                         >Savvy Agents</a
                     >.</span
                 >
-                <span>Docker-ready · Laravel-native · SES-backed</span>
+                <span>Docker-ready · Laravel-native · Provider-flexible</span>
             </div>
         </footer>
     </div>
@@ -1287,7 +1311,7 @@ footer a:hover {
 
 .features-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 14px;
 }
 

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\BuildProjectDashboard;
 use App\Models\ApiKey;
 use App\Models\Email;
 use App\Models\Project;
@@ -11,6 +12,8 @@ use App\Models\WebhookEndpoint;
 use App\Models\Workspace;
 use App\Support\ProjectContext;
 use Illuminate\Support\Str;
+
+use function Pest\Laravel\mock;
 
 it('routes incomplete first-run users to onboarding from dashboard', function () {
     $user = User::factory()->create();
@@ -31,6 +34,13 @@ it('renders the activity dashboard for authenticated users', function () {
             ->component('Activity')
             ->has('project')
             ->has('metrics', 6)
+            ->where('dashboard.outbound.total', 12)
+            ->where('dashboard.outbound.bounced', 1)
+            ->where('dashboard.outbound.complained', 1)
+            ->where('dashboard.configuration.verified_domains', 1)
+            ->where('dashboard.developer.active_webhooks', 2)
+            ->where('dashboard.developer.failing_webhooks', 1)
+            ->has('dashboard.trend', 8)
             ->has('recentThreads', 0)
             ->where('metrics', fn ($metrics) => collect($metrics)->every(fn (array $metric) => $metric['delta'] !== 'live'))
             ->has('suppressions', 2)
@@ -153,6 +163,9 @@ it('renders recent active inbox conversations on the dashboard', function () {
         'last_snippet' => 'Could you send another copy?',
         'message_count' => 2,
         'last_activity_at' => now(),
+        'status' => 'pending',
+        'priority' => 'urgent',
+        'assigned_to_user_id' => $user->id,
     ]);
 
     Thread::query()->create([
@@ -177,7 +190,59 @@ it('renders recent active inbox conversations on the dashboard', function () {
             ->where('recentThreads.0.public_id', 'thread_recent')
             ->where('recentThreads.0.subject', 'Need help with my receipt')
             ->where('recentThreads.0.unread', true)
+            ->where('recentThreads.0.status', 'pending')
+            ->where('recentThreads.0.priority', 'urgent')
+            ->where('recentThreads.0.assigned_to', $user->name)
             ->where('inboxUnread', 1)
+            ->where('dashboard.inbox.open', 1)
+            ->where('dashboard.inbox.mine', 1)
+            ->where('dashboard.inbox.unassigned', 0)
+            ->where('dashboard.inbox.urgent', 1)
+            ->where('dashboard.inbox.pending', 1)
+            ->where('dashboard.inbox.snoozed', 1)
+        );
+});
+
+it('keeps recent activity capped while dashboard totals remain exact', function () {
+    $user = User::factory()->create();
+    $project = seedActivityDashboardData($user);
+    $source = $project->sources()->firstOrFail();
+
+    foreach (range(1, 45) as $index) {
+        Email::create([
+            'public_id' => 'email_volume_'.$index,
+            'workspace_id' => $project->workspace_id,
+            'project_id' => $project->id,
+            'source_id' => $source->id,
+            'environment' => $source->environment,
+            'status' => 'delivered',
+            'from_email' => 'receipts@larasend.app',
+            'subject' => 'Volume message '.$index,
+        ]);
+    }
+
+    foreach (['queued', 'failed'] as $status) {
+        Email::create([
+            'public_id' => 'email_'.$status,
+            'workspace_id' => $project->workspace_id,
+            'project_id' => $project->id,
+            'source_id' => $source->id,
+            'environment' => $source->environment,
+            'status' => $status,
+            'from_email' => 'receipts@larasend.app',
+            'subject' => ucfirst($status).' message',
+        ]);
+    }
+
+    $this->actingAs($user)
+        ->get('/activity')
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->has('emails', 50)
+            ->where('dashboard.outbound.total', 59)
+            ->where('dashboard.outbound.queued', 1)
+            ->where('dashboard.outbound.failed', 1)
+            ->where('metrics.0.value', '57')
         );
 });
 
@@ -251,6 +316,42 @@ it('renders configuration routes with real project data', function () {
             ->has('domains', 1)
             ->has('webhooks', 2)
             ->has('apiKeys', 1)
+        );
+});
+
+it('does not build dashboard aggregates for non-dashboard sections', function () {
+    $user = User::factory()->create();
+    seedActivityDashboardData($user);
+
+    mock(BuildProjectDashboard::class)->shouldNotReceive('execute');
+
+    $this->actingAs($user)
+        ->get('/templates')
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('Activity')
+            ->where('section', 'templates')
+            ->where('dashboard', null)
+        );
+});
+
+it('only alerts for api keys that expire within the next seven days', function () {
+    $user = User::factory()->create();
+    $project = seedActivityDashboardData($user);
+    $source = $project->sources()->firstOrFail();
+
+    ApiKey::issue($project, 'Expired key', $source, expiresAt: now()->subDay());
+    ApiKey::issue($project, 'Expiring key', $source, expiresAt: now()->addDays(3));
+    ApiKey::issue($project, 'Later key', $source, expiresAt: now()->addDays(10));
+
+    $this->actingAs($user)
+        ->get('/activity')
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->where('dashboard.developer.expiring_api_keys', 1)
+            ->where('dashboard.attention', fn ($attention) => collect($attention)->contains(
+                fn (array $item): bool => $item['key'] === 'api-keys' && $item['count'] === 1,
+            ))
         );
 });
 

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use App\Models\Project;
+use App\Models\Source;
 use App\Models\User;
+use App\Models\Workspace;
+use App\Support\ProjectContext;
 
 test('profile page is displayed', function () {
     $user = User::factory()->create();
@@ -9,7 +13,38 @@ test('profile page is displayed', function () {
         ->actingAs($user)
         ->get(route('profile.edit'));
 
-    $response->assertOk();
+    $response
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('settings/Profile')
+            ->where('settingsNavigation', null)
+        );
+
+    expect(Workspace::query()->count())->toBe(0)
+        ->and(Project::query()->count())->toBe(0)
+        ->and(Source::query()->count())->toBe(0);
+});
+
+test('profile page keeps the project navigation for onboarded users', function () {
+    $user = User::factory()->create();
+
+    app(ProjectContext::class)->projectFor($user);
+
+    $response = $this
+        ->actingAs($user)
+        ->get(route('profile.edit'));
+
+    $response
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('settings/Profile')
+            ->where('settingsNavigation.project.name', 'My Project')
+            ->where('settingsNavigation.project.slug', 'my-project')
+            ->where('settingsNavigation.project.path', '/projects/my-project')
+            ->where('settingsNavigation.projects.0.is_current', true)
+            ->has('settingsNavigation.counts')
+            ->where('settingsNavigation.inbox_unread', 0)
+        );
 });
 
 test('profile information can be updated', function () {


### PR DESCRIPTION
## Summary

- refreshes the public homepage copy to reflect the current Larasend product: Amazon SES and Cloudflare sending, inbound email, the collaborative inbox, deliverability tooling, projects, roles, and operational health
- replaces the sparse dashboard with actionable outbound, inbox, configuration, developer, trend, and attention views backed by project data
- keeps account settings inside the same responsive project navigation used throughout the application
- removes the stray build label from the primary navigation while retaining deployment metadata in shared props
- preserves the latest suppression lifecycle behavior while rebasing the original refresh onto current main

## Why

Production was correctly deploying main, but the newer homepage and dashboard work was stranded on an unmerged branch. The live homepage therefore still described Larasend as an SES-only dashboard and omitted receiving, inbox collaboration, Cloudflare support, and the expanded operational workflow.

## Review hardening

Before publication, this branch was replayed onto current main and tightened to:

- calculate dashboard aggregates only for the dashboard route
- bound trend aggregation to the requested date range
- exclude already-expired API keys from the expiring-soon alert
- keep account-settings GET requests read-only instead of provisioning workspaces, projects, or sources
- collapse settings navigation counts into database-backed aggregate counts
- remove unrelated ESLint and Cloudflare Worker formatting changes from the original branch

## User impact

Visitors see product copy that matches the application available today. Authenticated users get a more complete operational dashboard and retain the primary project navigation when opening profile, security, or appearance settings.

## Validation

- php artisan test --compact tests/Feature/ActivityDashboardTest.php tests/Feature/Settings/ProfileUpdateTest.php tests/Feature/SuppressionManagementTest.php tests/Feature/DashboardActionsTest.php - 72 tests, 668 assertions
- vendor/bin/pint --dirty --format agent
- npm run types:check
- targeted ESLint checks for all changed Vue files
- targeted Prettier checks for all changed Vue files
- npm run build
- git diff --check origin/main...HEAD