### PR TITLE
Fix homepage command overflow

### DIFF
--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -1694,13 +1694,15 @@ pre {
 
 .install-cmd code {
     flex: 1;
-    overflow-x: auto;
+    min-width: 0;
+    overflow: hidden;
     color: #d8dee9;
     font:
         500 12.5px/1.6 'Geist Mono',
         ui-monospace,
         monospace;
     text-align: left;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
 

--- a/tests/Feature/HomeRouteTest.php
+++ b/tests/Feature/HomeRouteTest.php
@@ -29,3 +29,11 @@ test('home still renders the landing page for signed in users when enabled', fun
         ->assertOk()
         ->assertInertia(fn ($page) => $page->component('Welcome'));
 });
+
+test('landing page command preview clips overflow without a scrollbar', function () {
+    $welcomeSource = file_get_contents(resource_path('js/pages/Welcome.vue'));
+
+    expect($welcomeSource)
+        ->toMatch('/\\.install-cmd code \\{[^}]*min-width: 0;[^}]*overflow: hidden;[^}]*text-overflow: ellipsis;/s')
+        ->not->toMatch('/\\.install-cmd code \\{[^}]*overflow-x: auto;/s');
+});


### PR DESCRIPTION
## What changed

- remove the native horizontal scrollbar from homepage install commands
- keep each command on one line and show an ellipsis when it exceeds the available width
- preserve the full command for the Copy action
- add a regression test for the overflow styling

## Why

The command preview used horizontal scrolling for long install commands, which left a visually prominent scrollbar in the homepage call-to-action.

## Validation

- `php artisan test --compact tests/Feature/HomeRouteTest.php`
- `npx prettier --check resources/js/pages/Welcome.vue`
- `npx eslint resources/js/pages/Welcome.vue`
- `npm run types:check`
- `npm run build`
- browser verification with no console errors
