### PR TITLE
Fix inbox pagination navigation

### DIFF
--- a/app/Http/Controllers/InboxController.php
+++ b/app/Http/Controllers/InboxController.php
@@ -18,6 +18,8 @@ use Inertia\Response;
 
 class InboxController extends Controller
 {
+    private const THREADS_PER_PAGE = 50;
+
     public function __invoke(Request $request, ProjectContext $context): Response
     {
         $user = $request->user();
@@ -34,6 +36,7 @@ class InboxController extends Controller
         $assigned = $request->string('assigned')->toString();
         $page = max(1, $request->integer('page', 1));
         $threads = $this->threadsFor($project, $user->id, $mailbox, $address, $search, $assigned, $page);
+        $visibleThreads = $threads->take(self::THREADS_PER_PAGE);
         $selected = $this->selectedThread($project, $request->string('thread')->toString(), $threads->first()?->public_id);
 
         // Opening a conversation reads it — standard mail client behavior,
@@ -78,8 +81,15 @@ class InboxController extends Controller
                 'archived' => $project->threads()->whereNotNull('archived_at')->count(),
                 'closed' => $project->threads()->where('status', 'closed')->count(),
             ],
-            'threads' => $threads->take(50)->map(fn (Thread $thread): array => $this->serializeThread($thread, $user->id)),
-            'pagination' => ['page' => $page, 'has_more' => $threads->count() > 50],
+            'threads' => $visibleThreads->map(fn (Thread $thread): array => $this->serializeThread($thread, $user->id)),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => self::THREADS_PER_PAGE,
+                'from' => $visibleThreads->isEmpty() ? null : (($page - 1) * self::THREADS_PER_PAGE) + 1,
+                'to' => $visibleThreads->isEmpty() ? null : (($page - 1) * self::THREADS_PER_PAGE) + $visibleThreads->count(),
+                'has_previous' => $page > 1,
+                'has_more' => $threads->count() > self::THREADS_PER_PAGE,
+            ],
             'selectedThread' => $selected ? [
                 ...$this->serializeThread($selected, $user->id),
                 'messages' => $this->messagesFor($selected),
@@ -99,7 +109,7 @@ class InboxController extends Controller
     /**
      * @return Collection<int, Thread>
      */
-    private function threadsFor(Project $project, int $userId, string $mailbox, ?string $address, string $search, string $assigned, int $page)
+    private function threadsFor(Project $project, int $userId, string $mailbox, ?string $address, string $search, string $assigned, int $page): Collection
     {
         return $project->threads()
             ->tap(fn (Builder $query) => $this->applyMailbox($query, $mailbox, $userId))
@@ -119,9 +129,10 @@ class InboxController extends Controller
                 });
             })
             ->orderByDesc('last_activity_at')
+            ->orderByDesc('id')
             ->with(['assignedTo:id,name', 'userStates' => fn ($query) => $query->where('user_id', $userId)])
-            ->offset(($page - 1) * 50)
-            ->limit(51)
+            ->offset(($page - 1) * self::THREADS_PER_PAGE)
+            ->limit(self::THREADS_PER_PAGE + 1)
             ->get();
     }
 

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -8,6 +8,8 @@ import {
     AtSign,
     Bell,
     CheckSquare,
+    ChevronLeft,
+    ChevronRight,
     Forward,
     Inbox as InboxIcon,
     Mail,
@@ -113,7 +115,14 @@ const props = defineProps<{
         closed: number;
     };
     threads: ThreadRow[];
-    pagination: { page: number; has_more: boolean };
+    pagination: {
+        page: number;
+        per_page: number;
+        from: number | null;
+        to: number | null;
+        has_previous: boolean;
+        has_more: boolean;
+    };
     selectedThread:
         | (ThreadRow & {
               messages: Message[];
@@ -195,6 +204,7 @@ function visitInbox(params: Record<string, string | null>): void {
         q: searchQuery.value,
         assigned: props.filters.assigned,
         thread: props.selectedThread?.public_id ?? null,
+        page: props.pagination.page > 1 ? String(props.pagination.page) : null,
         ...params,
     };
 
@@ -212,7 +222,7 @@ function visitInbox(params: Record<string, string | null>): void {
 }
 
 function openMailbox(key: string): void {
-    visitInbox({ mailbox: key, thread: null });
+    visitInbox({ mailbox: key, page: null, thread: null });
 }
 
 function filterAddress(address: string): void {
@@ -224,13 +234,14 @@ function filterAssignment(assigned: string): void {
 }
 
 function setAssignmentFilter(assigned: string | null): void {
-    visitInbox({ assigned, thread: null });
+    visitInbox({ assigned, page: null, thread: null });
 }
 
 function setAddressFilter(address: string | null): void {
     visitInbox({
         mailbox: props.mailbox,
         address,
+        page: null,
         thread: null,
     });
 }
@@ -240,6 +251,7 @@ function clearFilters(): void {
         mailbox: props.mailbox,
         address: null,
         assigned: null,
+        page: null,
         thread: null,
     });
 }
@@ -254,7 +266,10 @@ function onSearchInput(): void {
         window.clearTimeout(searchTimer);
     }
 
-    searchTimer = window.setTimeout(() => visitInbox({ thread: null }), 350);
+    searchTimer = window.setTimeout(
+        () => visitInbox({ page: null, thread: null }),
+        350,
+    );
 }
 
 function threadAction(action: string): void {
@@ -599,7 +614,13 @@ watch(hasOpenOverlay, async (open, wasOpen) => {
 usePoll(
     10000,
     {
-        only: ['threads', 'counts', 'addresses', 'selectedThread'],
+        only: [
+            'threads',
+            'pagination',
+            'counts',
+            'addresses',
+            'selectedThread',
+        ],
         showProgress: false,
     },
     { autoStart: true },
@@ -1204,7 +1225,7 @@ function participantSummary(thread: ThreadRow): string {
             </aside>
 
             <section
-                class="min-h-0 grid-rows-[auto_minmax(0,1fr)] border-r border-zinc-200 md:grid dark:border-[#1d2125]"
+                class="min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] border-r border-zinc-200 md:grid dark:border-[#1d2125]"
                 :class="
                     selectedThread && mobileThreadOpen
                         ? 'hidden md:grid'
@@ -1398,27 +1419,44 @@ function participantSummary(thread: ThreadRow): string {
                             </span>
                         </div>
                     </button>
-                    <div
-                        v-if="pagination.page > 1 || pagination.has_more"
-                        class="flex gap-2 p-3"
-                    >
+                </div>
+                <div
+                    v-if="pagination.has_previous || pagination.has_more"
+                    class="flex items-center justify-between gap-2 border-t border-zinc-200 bg-white px-3 py-2 dark:border-[#1d2125] dark:bg-[#0b0c0d]"
+                    aria-label="Conversation pagination"
+                >
+                    <p class="min-w-0 truncate text-[11px] text-zinc-500">
+                        <span
+                            class="font-semibold text-zinc-700 dark:text-zinc-300"
+                        >
+                            {{ pagination.from }}–{{ pagination.to }}
+                        </span>
+                        conversations · Page {{ pagination.page }}
+                    </p>
+                    <div class="flex shrink-0 items-center gap-1">
                         <button
-                            v-if="pagination.page > 1"
                             type="button"
-                            class="flex-1 rounded-md border border-zinc-200 py-2 text-xs font-semibold dark:border-[#1d2125]"
+                            class="inline-flex h-8 items-center gap-1 rounded-md border border-zinc-200 px-2 text-[11px] font-semibold text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35 dark:border-[#25292d] dark:text-zinc-300 dark:hover:border-[#34393e] dark:hover:bg-[#151719]"
+                            :disabled="!pagination.has_previous"
+                            aria-label="Show newer conversations"
                             @click="
                                 visitInbox({
-                                    page: String(pagination.page - 1),
+                                    page:
+                                        pagination.page - 1 > 1
+                                            ? String(pagination.page - 1)
+                                            : null,
                                     thread: null,
                                 })
                             "
                         >
-                            Previous
+                            <ChevronLeft class="size-3.5" />
+                            Newer
                         </button>
                         <button
-                            v-if="pagination.has_more"
                             type="button"
-                            class="flex-1 rounded-md border border-zinc-200 py-2 text-xs font-semibold dark:border-[#1d2125]"
+                            class="inline-flex h-8 items-center gap-1 rounded-md border border-zinc-200 px-2 text-[11px] font-semibold text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35 dark:border-[#25292d] dark:text-zinc-300 dark:hover:border-[#34393e] dark:hover:bg-[#151719]"
+                            :disabled="!pagination.has_more"
+                            aria-label="Show older conversations"
                             @click="
                                 visitInbox({
                                     page: String(pagination.page + 1),
@@ -1426,7 +1464,8 @@ function participantSummary(thread: ThreadRow): string {
                                 })
                             "
                         >
-                            Next 50
+                            Older
+                            <ChevronRight class="size-3.5" />
                         </button>
                     </div>
                 </div>

--- a/tests/Feature/InboxTest.php
+++ b/tests/Feature/InboxTest.php
@@ -82,6 +82,52 @@ it('renders the inbox with threads, counts, and interleaved messages', function 
             ->where('addresses.0.address', 'support@example.com'));
 });
 
+it('paginates conversations with stable ordering and page metadata', function () {
+    [$user, $project] = inboxFixture();
+    $lastActivityAt = now();
+
+    foreach (range(1, 51) as $number) {
+        Thread::query()->create([
+            'public_id' => "thread-pagination-{$number}",
+            'workspace_id' => $project->workspace_id,
+            'project_id' => $project->id,
+            'subject' => "Conversation {$number}",
+            'subject_key' => "conversation {$number}",
+            'participants' => ["customer{$number}@example.com"],
+            'last_direction' => 'inbound',
+            'last_snippet' => "Message {$number}",
+            'message_count' => 1,
+            'last_activity_at' => $lastActivityAt,
+        ]);
+    }
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/inbox?mailbox=inbox")
+        ->assertInertia(fn ($page) => $page
+            ->has('threads', 50)
+            ->where('threads.0.subject', 'Conversation 51')
+            ->where('threads.49.subject', 'Conversation 2')
+            ->where('pagination.page', 1)
+            ->where('pagination.per_page', 50)
+            ->where('pagination.from', 1)
+            ->where('pagination.to', 50)
+            ->where('pagination.has_previous', false)
+            ->where('pagination.has_more', true));
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/inbox?mailbox=inbox&page=2")
+        ->assertInertia(fn ($page) => $page
+            ->has('threads', 1)
+            ->where('threads.0.subject', 'Conversation 1')
+            ->where('selectedThread.subject', 'Conversation 1')
+            ->where('pagination.page', 2)
+            ->where('pagination.per_page', 50)
+            ->where('pagination.from', 51)
+            ->where('pagination.to', 51)
+            ->where('pagination.has_previous', true)
+            ->where('pagination.has_more', false));
+});
+
 it('keeps address views stable and counts distinct conversations', function () {
     [$user, $project, $source] = inboxFixture();
 


### PR DESCRIPTION
## What changed

- keep inbox pagination controls visible below the scrolling conversation list
- show the visible conversation range and provide clear Newer/Older navigation
- preserve the current page when opening a conversation
- reset to page one when mailbox, search, assignee, or address filters change
- stabilize equal-timestamp pagination with an ID tie-breaker
- refresh pagination metadata during inbox polling

## Why

The previous controls were rendered after all 50 rows inside the independently scrolling list, which made older conversations appear inaccessible. Opening a conversation from page two also dropped the page parameter and snapped the list back to page one.

## Verification

- `php artisan test --compact` — 334 tests, 2,134 assertions
- `composer audit --locked --no-interaction`
- `composer validate --strict --no-interaction`
- `npm run format:check`
- `npm run lint:check`
- `npm run types:check`
- `npm run build`
- browser verified page 1 → page 2 navigation, page retention after opening a conversation, light/dark presentation, and zero console warnings/errors
