### PR TITLE
Prevent FastCGI header overflow on app pages

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -24,6 +24,10 @@ server {
     location ~ \.php$ {
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_index index.php;
+        # Inertia's Vite preload links can exceed nginx's platform-default
+        # first FastCGI response buffer before the response body begins.
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 8 16k;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
         fastcgi_param HTTP_X_FORWARDED_PROTO $larasend_forwarded_proto;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5452,9 +5452,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## Summary
- increase the first FastCGI response buffer for Inertia/Vite preload headers
- keep companion FastCGI buffers consistent with nginx validation requirements
- prevent production app and login pages from returning 502 when response headers exceed the platform default
- update transitive nanoid from 3.3.17 to patched 3.3.18 after the live security audit began blocking CI

## Verification
- measured the upgraded production-data rehearsal response at 5,337 header bytes with a 4,293-byte largest header
- ran all 19 pending migrations successfully against a fresh production-data PostgreSQL clone
- built the complete Docker image locally
- nginx configuration test passed
- isolated seeded preview returned HTTP 200 for /up, /, and /login
- npm audit --audit-level=high reports zero vulnerabilities

## Risk and rollback
- nginx response-buffer configuration plus a transitive patch-level lockfile update
- no PHP application, database migration, queue, or integration code changes
- rollback is reverting these commits and rebuilding the image