### PR TITLE
Paginate Inbox and Outbound email

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -26,6 +26,19 @@ use Inertia\Response;
 
 class ActivityController extends Controller
 {
+    private const EMAILS_PER_PAGE = 50;
+
+    private const FILTERABLE_EMAIL_STATUSES = [
+        'delivered',
+        'opened',
+        'clicked',
+        'queued',
+        'sending',
+        'bounced',
+        'complained',
+        'failed',
+    ];
+
     public function __construct(
         private EmailProviderFactory $providers,
         private SystemHealth $systemHealth,
@@ -62,9 +75,24 @@ class ActivityController extends Controller
             return redirect($context->sectionPath($project, 'identities'));
         }
 
-        $emails = $this->activityEmailsQuery($project, $request, $section)
-            ->limit(50)
-            ->get();
+        $emailPage = $section === 'outbound' ? max(1, $request->integer('page', 1)) : 1;
+        $emailStatus = $this->selectedEmailStatus($request, $section);
+        $emailQuery = $this->activityEmailsQuery($project, $request, $section);
+        $emailStatusCounts = $section === 'outbound'
+            ? $this->emailStatusCounts(clone $emailQuery)
+            : [];
+
+        if ($emailStatus !== '') {
+            $emailQuery->where('status', $emailStatus);
+        }
+
+        $emailRows = $section === 'outbound'
+            ? $emailQuery
+                ->offset(($emailPage - 1) * self::EMAILS_PER_PAGE)
+                ->limit(self::EMAILS_PER_PAGE + 1)
+                ->get()
+            : $emailQuery->limit(self::EMAILS_PER_PAGE)->get();
+        $emails = $emailRows->take(self::EMAILS_PER_PAGE);
 
         $selected = $emails->first();
         $canSend = $source ? $this->canSend($project, $source) : false;
@@ -145,12 +173,22 @@ class ActivityController extends Controller
             'filters' => [
                 'q' => $request->string('q')->toString(),
                 'range' => $range,
+                'status' => $emailStatus,
             ],
             'metrics' => $this->metrics($project, $range),
             'dashboard' => $dashboard,
             'bounceMetrics' => $this->bounceMetrics($project),
             'bounceQueue' => $this->bounceQueue($project, $request),
             'emails' => $emails->map(fn (Email $email) => $this->serializeEmail($email, detailed: true)),
+            'emailPagination' => [
+                'page' => $emailPage,
+                'per_page' => self::EMAILS_PER_PAGE,
+                'from' => $emails->isEmpty() ? null : (($emailPage - 1) * self::EMAILS_PER_PAGE) + 1,
+                'to' => $emails->isEmpty() ? null : (($emailPage - 1) * self::EMAILS_PER_PAGE) + $emails->count(),
+                'has_previous' => $emailPage > 1,
+                'has_more' => $section === 'outbound' && $emailRows->count() > self::EMAILS_PER_PAGE,
+            ],
+            'emailStatusCounts' => $emailStatusCounts,
             'selectedEmail' => $selected ? $this->serializeEmail($selected, detailed: true) : null,
             'source' => $source ? [
                 'name' => $source->name,
@@ -400,7 +438,8 @@ class ActivityController extends Controller
     {
         $query = $project->emails()
             ->with(['recipients', 'events', 'attachments', 'source', 'template'])
-            ->latest();
+            ->latest()
+            ->orderByDesc('id');
 
         match ($section) {
             'sent' => $query->whereIn('status', ['sent', 'delivered', 'opened', 'clicked']),
@@ -436,6 +475,33 @@ class ActivityController extends Controller
         }
 
         return $query;
+    }
+
+    private function selectedEmailStatus(Request $request, string $section): string
+    {
+        if ($section !== 'outbound') {
+            return '';
+        }
+
+        $status = Str::lower(trim($request->string('status')->toString()));
+
+        return in_array($status, self::FILTERABLE_EMAIL_STATUSES, true) ? $status : '';
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function emailStatusCounts(HasMany $query): array
+    {
+        $counts = $query
+            ->reorder()
+            ->selectRaw('status, COUNT(*) AS aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status')
+            ->map(fn (mixed $count): int => (int) $count)
+            ->all();
+
+        return ['all' => array_sum($counts), ...$counts];
     }
 
     private function activeInboxThreads(Project $project): HasMany

--- a/resources/js/components/PaginationControls.vue
+++ b/resources/js/components/PaginationControls.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next';
+
+withDefaults(
+    defineProps<{
+        page: number;
+        from: number | null;
+        to: number | null;
+        hasPrevious: boolean;
+        hasMore: boolean;
+        noun: string;
+        previousLabel?: string;
+        nextLabel?: string;
+    }>(),
+    {
+        previousLabel: 'Previous',
+        nextLabel: 'Next',
+    },
+);
+
+defineEmits<{
+    previous: [];
+    next: [];
+}>();
+</script>
+
+<template>
+    <div
+        v-if="hasPrevious || hasMore"
+        class="flex items-center justify-between gap-2 border-t border-zinc-200 bg-white px-3 py-2 dark:border-[#1d2125] dark:bg-[#0b0c0d]"
+        :aria-label="`${noun} pagination`"
+    >
+        <p class="min-w-0 truncate text-[11px] text-zinc-500">
+            <template v-if="from !== null && to !== null">
+                <span class="font-semibold text-zinc-700 dark:text-zinc-300">
+                    {{ from }}–{{ to }}
+                </span>
+                {{ noun }} ·
+            </template>
+            Page {{ page }}
+        </p>
+        <div class="flex shrink-0 items-center gap-1">
+            <button
+                type="button"
+                class="inline-flex h-8 items-center gap-1 rounded-md border border-zinc-200 px-2 text-[11px] font-semibold text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35 dark:border-[#25292d] dark:text-zinc-300 dark:hover:border-[#34393e] dark:hover:bg-[#151719]"
+                :disabled="!hasPrevious"
+                :aria-label="`Show previous ${noun}`"
+                @click="$emit('previous')"
+            >
+                <ChevronLeft class="size-3.5" />
+                {{ previousLabel }}
+            </button>
+            <button
+                type="button"
+                class="inline-flex h-8 items-center gap-1 rounded-md border border-zinc-200 px-2 text-[11px] font-semibold text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35 dark:border-[#25292d] dark:text-zinc-300 dark:hover:border-[#34393e] dark:hover:bg-[#151719]"
+                :disabled="!hasMore"
+                :aria-label="`Show next ${noun}`"
+                @click="$emit('next')"
+            >
+                {{ nextLabel }}
+                <ChevronRight class="size-3.5" />
+            </button>
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -29,7 +29,9 @@ import {
 import DashboardPanel from '@/components/DashboardPanel.vue';
 import EmailProviderPanel from '@/components/EmailProviderPanel.vue';
 import GlobalRail from '@/components/GlobalRail.vue';
+import PaginationControls from '@/components/PaginationControls.vue';
 import { Toaster } from '@/components/ui/sonner';
+import { section as projectSectionRoute } from '@/routes/projects';
 import { transfer as transferWorkspaceOwnershipRoute } from '@/routes/workspace-members/ownership';
 
 type Metric = {
@@ -206,7 +208,7 @@ const props = defineProps<{
     projects: ProjectOption[];
     archivedProjects: ArchivedProjectOption[];
     section: string;
-    filters: { q: string; range: string };
+    filters: { q: string; range: string; status: string };
     metrics: Metric[];
     dashboard: {
         outbound: {
@@ -262,6 +264,15 @@ const props = defineProps<{
     bounceMetrics: BounceMetric[];
     bounceQueue: BounceQueueRow[];
     emails: EmailRow[];
+    emailPagination: {
+        page: number;
+        per_page: number;
+        from: number | null;
+        to: number | null;
+        has_previous: boolean;
+        has_more: boolean;
+    };
+    emailStatusCounts: Record<string, number>;
     selectedEmail: EmailDetail | null;
     sidebarCounts: Record<string, number>;
     inboxUnread?: number;
@@ -431,7 +442,7 @@ const statusFilters = [
     'Complained',
     'Failed',
 ];
-const selectedFilter = ref('All');
+const selectedFilter = ref(statusFilterLabel(props.filters.status));
 const searchQuery = ref(props.filters.q);
 const searchInput = ref<HTMLInputElement | null>(null);
 const selectedRange = ref(props.filters.range || '14d');
@@ -584,12 +595,12 @@ const filteredEmails = computed(() => {
 });
 
 const statusFilterCounts = computed(() => {
-    const counts: Record<string, number> = { All: props.emails.length };
+    const counts: Record<string, number> = {
+        All: props.emailStatusCounts.all ?? 0,
+    };
 
     for (const filter of statusFilters.slice(1)) {
-        counts[filter] = props.emails.filter(
-            (email) => email.status === filter.toLowerCase(),
-        ).length;
+        counts[filter] = props.emailStatusCounts[filter.toLowerCase()] ?? 0;
     }
 
     return counts;
@@ -705,6 +716,12 @@ const complaintRate = computed(
 );
 const projectBasePath = computed(() => `/projects/${props.project.slug}`);
 const sectionPath = computed(() => sectionHref(props.section));
+const emailRefreshHref = computed(() =>
+    projectSectionRoute.url(
+        { project: props.project.slug, section: props.section },
+        { query: emailLogQuery() },
+    ),
+);
 const exportHref = computed(() => {
     const params = new URLSearchParams({
         section: props.section,
@@ -719,7 +736,10 @@ const exportHref = computed(() => {
 });
 
 function sectionHref(section: string): string {
-    return `${projectBasePath.value}/${section}`;
+    return projectSectionRoute.url({
+        project: props.project.slug,
+        section,
+    });
 }
 
 function projectAction(path: string): string {
@@ -770,6 +790,8 @@ usePoll(
     {
         only: [
             'emails',
+            'emailPagination',
+            'emailStatusCounts',
             'selectedEmail',
             'metrics',
             'bounceMetrics',
@@ -815,7 +837,18 @@ watch(
                 ...selected.value,
                 ...refreshed,
             };
+
+            return;
         }
+
+        selected.value = props.selectedEmail;
+    },
+);
+
+watch(
+    () => props.filters.status,
+    (status) => {
+        selectedFilter.value = statusFilterLabel(status);
     },
 );
 
@@ -1533,17 +1566,91 @@ function closeInspector(): void {
     selected.value = null;
 }
 
-function applySearch(): void {
-    router.get(
-        sectionPath.value,
-        { q: searchQuery.value, range: selectedRange.value },
-        { preserveState: true, preserveScroll: true, replace: true },
+type EmailLogQuery = {
+    q?: string | null;
+    range?: string | null;
+    status?: string | null;
+    page?: number | null;
+};
+
+function statusFilterLabel(status: string): string {
+    const match = statusFilters.find(
+        (filter) => filter.toLowerCase() === status.toLowerCase(),
     );
+
+    return match ?? 'All';
+}
+
+function statusFilterValue(filter: string): string | null {
+    return filter === 'All' ? null : filter.toLowerCase();
+}
+
+function emailLogQuery(overrides: EmailLogQuery = {}): Record<string, string> {
+    const merged: EmailLogQuery = {
+        q: searchQuery.value || null,
+        range: selectedRange.value,
+        status: statusFilterValue(selectedFilter.value),
+        page:
+            props.emailPagination.page > 1 ? props.emailPagination.page : null,
+        ...overrides,
+    };
+    const query: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(merged)) {
+        if (value !== null && value !== '') {
+            query[key] = String(value);
+        }
+    }
+
+    return query;
+}
+
+function visitEmailLog(overrides: EmailLogQuery, replace = true): void {
+    if (Object.prototype.hasOwnProperty.call(overrides, 'page')) {
+        selected.value = null;
+    }
+
+    router.get(sectionPath.value, emailLogQuery(overrides), {
+        preserveState: true,
+        preserveScroll: true,
+        replace,
+    });
+}
+
+function applySearch(): void {
+    visitEmailLog({ q: searchQuery.value, page: null });
 }
 
 function setRange(range: string): void {
     selectedRange.value = range;
-    applySearch();
+    visitEmailLog({ range, page: null });
+}
+
+function setStatusFilter(filter: string): void {
+    selectedFilter.value = filter;
+    visitEmailLog({ status: statusFilterValue(filter), page: null });
+}
+
+function clearEmailFilters(): void {
+    selectedFilter.value = 'All';
+    searchQuery.value = '';
+    visitEmailLog({ q: null, status: null, page: null });
+}
+
+function showPreviousEmailPage(): void {
+    visitEmailLog(
+        {
+            page:
+                props.emailPagination.page - 1 > 1
+                    ? props.emailPagination.page - 1
+                    : null,
+        },
+        false,
+    );
+}
+
+function showNextEmailPage(): void {
+    visitEmailLog({ page: props.emailPagination.page + 1 }, false);
 }
 
 function startOfDay(date: Date): Date {
@@ -1826,7 +1933,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                 <div class="ml-auto flex items-center gap-1.5" v-else />
                 <Link
                     v-if="isMailSection"
-                    :href="`${sectionPath}?q=${encodeURIComponent(searchQuery)}&range=${encodeURIComponent(selectedRange)}`"
+                    :href="emailRefreshHref"
                     class="grid size-8 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-950 dark:text-[#9aa0a6] dark:hover:bg-[#16191c] dark:hover:text-zinc-100"
                     title="Refresh"
                 >
@@ -2304,7 +2411,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                                         'border-zinc-300 bg-zinc-100 text-zinc-950 dark:border-[#262b30] dark:bg-[#1a1e22] dark:text-zinc-100':
                                             selectedFilter === filter,
                                     }"
-                                    @click="selectedFilter = filter"
+                                    @click="setStatusFilter(filter)"
                                 >
                                     {{ filter }}
                                     <span
@@ -2317,11 +2424,7 @@ function recipientTitle(email: EmailRow): string | undefined {
                             </div>
                             <button
                                 class="inline-flex h-[26px] shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 font-sans text-[11.5px] text-zinc-500 hover:text-zinc-950 dark:border-[#1d2125] dark:bg-[#111315] dark:text-[#9aa0a6] dark:hover:text-zinc-100"
-                                @click="
-                                    selectedFilter = 'All';
-                                    searchQuery = '';
-                                    applySearch();
-                                "
+                                @click="clearEmailFilters"
                             >
                                 <SlidersHorizontal class="size-4" /> Clear
                             </button>
@@ -2414,6 +2517,18 @@ function recipientTitle(email: EmailRow): string | undefined {
                                 </button>
                             </template>
                         </div>
+                        <PaginationControls
+                            :page="emailPagination.page"
+                            :from="emailPagination.from"
+                            :to="emailPagination.to"
+                            :has-previous="emailPagination.has_previous"
+                            :has-more="emailPagination.has_more"
+                            noun="emails"
+                            previous-label="Newer"
+                            next-label="Older"
+                            @previous="showPreviousEmailPage"
+                            @next="showNextEmailPage"
+                        />
                     </section>
 
                     <aside

--- a/resources/js/pages/Inbox.vue
+++ b/resources/js/pages/Inbox.vue
@@ -8,8 +8,6 @@ import {
     AtSign,
     Bell,
     CheckSquare,
-    ChevronLeft,
-    ChevronRight,
     Forward,
     Inbox as InboxIcon,
     Mail,
@@ -35,6 +33,7 @@ import {
     watch,
 } from 'vue';
 import GlobalRail from '@/components/GlobalRail.vue';
+import PaginationControls from '@/components/PaginationControls.vue';
 import RichTextEditor from '@/components/RichTextEditor.vue';
 import { Toaster } from '@/components/ui/sonner';
 import { inbox as inboxRoute } from '@/routes/projects';
@@ -218,6 +217,23 @@ function visitInbox(params: Record<string, string | null>): void {
         preserveState: true,
         preserveScroll: true,
         showProgress: false,
+    });
+}
+
+function showPreviousThreadPage(): void {
+    visitInbox({
+        page:
+            props.pagination.page - 1 > 1
+                ? String(props.pagination.page - 1)
+                : null,
+        thread: null,
+    });
+}
+
+function showNextThreadPage(): void {
+    visitInbox({
+        page: String(props.pagination.page + 1),
+        thread: null,
     });
 }
 
@@ -1420,55 +1436,18 @@ function participantSummary(thread: ThreadRow): string {
                         </div>
                     </button>
                 </div>
-                <div
-                    v-if="pagination.has_previous || pagination.has_more"
-                    class="flex items-center justify-between gap-2 border-t border-zinc-200 bg-white px-3 py-2 dark:border-[#1d2125] dark:bg-[#0b0c0d]"
-                    aria-label="Conversation pagination"
-                >
-                    <p class="min-w-0 truncate text-[11px] text-zinc-500">
-                        <span
-                            class="font-semibold text-zinc-700 dark:text-zinc-300"
-                        >
-                            {{ pagination.from }}–{{ pagination.to }}
-                        </span>
-                        conversations · Page {{ pagination.page }}
-                    </p>
-                    <div class="flex shrink-0 items-center gap-1">
-                        <button
-                            type="button"
-                            class="inline-flex h-8 items-center gap-1 rounded-md border border-zinc-200 px-2 text-[11px] font-semibold text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35 dark:border-[#25292d] dark:text-zinc-300 dark:hover:border-[#34393e] dark:hover:bg-[#151719]"
-                            :disabled="!pagination.has_previous"
-                            aria-label="Show newer conversations"
-                            @click="
-                                visitInbox({
-                                    page:
-                                        pagination.page - 1 > 1
-                                            ? String(pagination.page - 1)
-                                            : null,
-                                    thread: null,
-                                })
-                            "
-                        >
-                            <ChevronLeft class="size-3.5" />
-                            Newer
-                        </button>
-                        <button
-                            type="button"
-                            class="inline-flex h-8 items-center gap-1 rounded-md border border-zinc-200 px-2 text-[11px] font-semibold text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-35 dark:border-[#25292d] dark:text-zinc-300 dark:hover:border-[#34393e] dark:hover:bg-[#151719]"
-                            :disabled="!pagination.has_more"
-                            aria-label="Show older conversations"
-                            @click="
-                                visitInbox({
-                                    page: String(pagination.page + 1),
-                                    thread: null,
-                                })
-                            "
-                        >
-                            Older
-                            <ChevronRight class="size-3.5" />
-                        </button>
-                    </div>
-                </div>
+                <PaginationControls
+                    :page="pagination.page"
+                    :from="pagination.from"
+                    :to="pagination.to"
+                    :has-previous="pagination.has_previous"
+                    :has-more="pagination.has_more"
+                    noun="conversations"
+                    previous-label="Newer"
+                    next-label="Older"
+                    @previous="showPreviousThreadPage"
+                    @next="showNextThreadPage"
+                />
             </section>
 
             <section

--- a/tests/Feature/ActivityDashboardTest.php
+++ b/tests/Feature/ActivityDashboardTest.php
@@ -265,6 +265,83 @@ it('renders every outbound delivery state in the outbound log', function () {
         ->assertRedirect('/projects/my-project/outbound');
 });
 
+it('paginates filtered outbound email with stable ordering and page metadata', function () {
+    $user = User::factory()->create();
+    $project = seedActivityDashboardData($user);
+    $source = $project->sources()->firstOrFail();
+    $createdAt = now()->subMinute()->startOfSecond();
+
+    foreach (range(1, 51) as $number) {
+        $email = Email::create([
+            'public_id' => 'email_pagination_'.$number,
+            'workspace_id' => $project->workspace_id,
+            'project_id' => $project->id,
+            'source_id' => $source->id,
+            'environment' => $source->environment,
+            'status' => 'delivered',
+            'from_email' => 'receipts@larasend.app',
+            'subject' => 'Pagination message '.$number,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+
+        $email->recipients()->create([
+            'type' => 'to',
+            'email' => "recipient{$number}@example.com",
+        ]);
+    }
+
+    Email::create([
+        'public_id' => 'email_pagination_failed',
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $source->id,
+        'environment' => $source->environment,
+        'status' => 'failed',
+        'from_email' => 'receipts@larasend.app',
+        'subject' => 'Pagination message failed',
+        'created_at' => $createdAt,
+        'updated_at' => $createdAt,
+    ]);
+
+    $query = 'q=Pagination%20message&range=30d&status=delivered';
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/outbound?{$query}&page=-3")
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->has('emails', 50)
+            ->where('emails.0.subject', 'Pagination message 51')
+            ->where('emails.49.subject', 'Pagination message 2')
+            ->where('selectedEmail.subject', 'Pagination message 51')
+            ->where('filters.status', 'delivered')
+            ->where('emailStatusCounts.all', 52)
+            ->where('emailStatusCounts.delivered', 51)
+            ->where('emailStatusCounts.failed', 1)
+            ->where('emailPagination.page', 1)
+            ->where('emailPagination.per_page', 50)
+            ->where('emailPagination.from', 1)
+            ->where('emailPagination.to', 50)
+            ->where('emailPagination.has_previous', false)
+            ->where('emailPagination.has_more', true));
+
+    $this->actingAs($user)
+        ->get("/projects/{$project->slug}/outbound?{$query}&page=2")
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->has('emails', 1)
+            ->where('emails.0.subject', 'Pagination message 1')
+            ->where('selectedEmail.subject', 'Pagination message 1')
+            ->where('filters.q', 'Pagination message')
+            ->where('filters.range', '30d')
+            ->where('filters.status', 'delivered')
+            ->where('emailPagination.page', 2)
+            ->where('emailPagination.from', 51)
+            ->where('emailPagination.to', 51)
+            ->where('emailPagination.has_previous', true)
+            ->where('emailPagination.has_more', false));
+});
+
 it('calculates activity metric deltas against the previous matching period', function () {
     $user = User::factory()->create();
     $project = seedActivityDashboardData($user);


### PR DESCRIPTION
## Summary

- add stable 50-email server-side pagination to Outbound with a 51st-row look-ahead
- apply search, date range, and status filters before pagination and return range-aware status counts
- reuse one fixed pagination footer in Inbox and Outbound so controls remain outside the scrolling list
- preserve filters while paging, reset to page one when filters change, and avoid showing stale email details after navigation

## Tests run

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact` — 335 tests, 2,198 assertions
- `npm run format:check`
- `npm run lint:check`
- `npm run types:check`
- `npm run build`
- `composer audit --locked --no-interaction`
- `npm audit --audit-level=high`

## Risk and rollback

Low risk: this changes read-only list queries and pagination UI only. There are no migrations, sending-path changes, credential changes, or background-job changes. Offset pages may shift when new email arrives, but `(created_at, id)` ordering keeps equal-timestamp boundaries deterministic. Roll back by reverting `f338a9c`.
