### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ This project follows Laravel conventions closely: controllers stay thin, busines
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=savvyagents/larasend&type=Date)](https://www.star-history.com/#savvyagents/larasend&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=savvyagents/larasend&type=Date)](https://star-history.dera.page/#savvyagents/larasend&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This switches it to a working mirror that serves the chart from the same domain, so the image renders again without requiring an API token.