### PR TITLE
Fix webhook signing secret never being revealed after creation

### DIFF
--- a/resources/js/pages/Activity.vue
+++ b/resources/js/pages/Activity.vue
@@ -525,6 +525,15 @@ watch(
         }
     },
 );
+watch(
+    () => props.newWebhookEndpoint,
+    (newWebhookEndpoint) => {
+        if (newWebhookEndpoint) {
+            revealedWebhookEndpoint.value = newWebhookEndpoint;
+            webhookSecretCopied.value = false;
+        }
+    },
+);
 const projectForm = reactive({
     name: '',
     slug: '',


### PR DESCRIPTION
## The bug
Creating a webhook endpoint flashes `newWebhookEndpoint` (with the one-time plain-text signing secret) back to the Activity page, and the toast says *"Copy the signing secret now; it will not be shown again"* - but the reveal dialog never opens, so the secret is unrecoverable the moment it's created. Since webhook endpoints (unlike API keys) have no rotate action, the only workaround is decrypting `signing_secret` in tinker or recreating the endpoint (which hits the same bug again).

## Cause
`revealedWebhookEndpoint = ref(props.newWebhookEndpoint)` captures the prop once at setup. After the store redirect, Inertia updates props in place without remounting the page, so the ref stays `null` and `v-if="revealedWebhookEndpoint"` never shows the dialog. The API-key flow works because it has a `watch` on `props.newApiKey` doing exactly this.

## Fix
Mirror the `newApiKey` watch for `newWebhookEndpoint` (and reset the copied flag), so the flashed endpoint opens the reveal dialog.

Found while wiring a consumer of the outbound webhooks against a self-hosted instance (commit `da5c06c`). Related gaps we may PR separately: webhook endpoints have no delete or secret-rotate action.