### PR TITLE
Fix SES event correlation for shared SNS webhooks

### DIFF
--- a/app/Services/SesEventNormalizer.php
+++ b/app/Services/SesEventNormalizer.php
@@ -25,9 +25,11 @@ class SesEventNormalizer
         $sesMessageId = $message['messageId'] ?? null;
         $detail = $payload[$eventType] ?? $payload[ucfirst($eventType)] ?? [];
         $recipient = $this->recipient($eventType, $detail, $message);
-        $email = $sesMessageId
-            ? Email::query()->where('source_id', $source->id)->where('ses_message_id', $sesMessageId)->first()
-            : null;
+        $emailMatches = $sesMessageId
+            ? Email::query()->with('source')->where('ses_message_id', $sesMessageId)->limit(2)->get()
+            : collect();
+        $email = $emailMatches->count() === 1 ? $emailMatches->first() : null;
+        $source = $email?->source ?? $source;
         $providerEventId = hash('sha256', $source->id.'|'.($providerMessageId ?: json_encode($payload, JSON_THROW_ON_ERROR)));
         $existing = EmailEvent::query()->where('provider_event_id', $providerEventId)->first();
 

--- a/tests/Feature/SesWebhookTest.php
+++ b/tests/Feature/SesWebhookTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Email;
+use App\Models\EmailEvent;
 use App\Models\Project;
 use App\Models\Source;
 use App\Models\Suppression;
@@ -129,6 +130,47 @@ it('normalizes ses delivery events', function () {
 
     expect($email->fresh()->status)->toBe('delivered')
         ->and($email->events()->where('event_type', 'delivery')->exists())->toBeTrue();
+});
+
+it('correlates events delivered through another source webhook', function () {
+    [$webhookSource] = sesWebhookFixture();
+    $project = Project::create([
+        'workspace_id' => $webhookSource->project->workspace_id,
+        'name' => 'Shared SNS Project',
+        'slug' => 'shared-sns-project',
+    ]);
+    $emailSource = Source::create([
+        'project_id' => $project->id,
+        'name' => 'Shared SNS Source',
+        'webhook_token' => 'shared-sns-source-token',
+    ]);
+    $email = Email::create([
+        'public_id' => 'email_shared_sns',
+        'workspace_id' => $project->workspace_id,
+        'project_id' => $project->id,
+        'source_id' => $emailSource->id,
+        'status' => 'sent',
+        'ses_message_id' => 'ses-shared-sns',
+        'from_email' => 'receipts@example.com',
+        'subject' => 'Shared SNS receipt',
+    ]);
+
+    Http::fake([SES_TEST_SIGNING_CERT_URL => Http::response(sesTestPublicCertificate())]);
+
+    $message = [
+        'eventType' => 'Delivery',
+        'mail' => ['messageId' => 'ses-shared-sns', 'timestamp' => now()->toIso8601String(), 'destination' => ['maya@example.com']],
+        'delivery' => ['recipients' => ['maya@example.com'], 'timestamp' => now()->toIso8601String()],
+    ];
+
+    $this->postJson(
+        "/api/webhooks/ses/{$webhookSource->webhook_token}",
+        sesSignedSnsEnvelope('Notification', ['Message' => json_encode($message)]),
+    )->assertSuccessful();
+
+    expect($email->fresh()->status)->toBe('delivered')
+        ->and($email->events()->where('event_type', 'delivery')->value('source_id'))->toBe($emailSource->id)
+        ->and(EmailEvent::query()->where('source_id', $webhookSource->id)->where('ses_message_id', 'ses-shared-sns')->exists())->toBeFalse();
 });
 
 it('deduplicates repeated sns notifications by message id', function () {


### PR DESCRIPTION
## Summary
- correlate signed SES events globally by SES message ID when a configuration set routes multiple Larasend sources through one SNS subscription
- attribute matched events to the email's actual source
- retain the receiving webhook source for unmatched or ambiguous message IDs
- add regression coverage for cross-source webhook delivery

## Verification
- `composer test`
- 336 tests passed, 2202 assertions